### PR TITLE
Add callbacks to logger flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ metrics.histogram('test.service_time', 0.248);
 
 ### Flushing
 
-`metrics.flush()`
+`metrics.flush([onSuccess[, onError]])`
 
 Calling `flush` sends any buffered metrics to DataDog. Unless you set
 `flushIntervalSeconds` to 0 it won't be necessary to call this function.

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -78,11 +78,11 @@ BufferedMetricsLogger.prototype.histogram = function(key, value, tags) {
     this.addPoint(Histogram, key, value, tags);
 };
 
-BufferedMetricsLogger.prototype.flush = function() {
+BufferedMetricsLogger.prototype.flush = function(onSuccess, onError) {
     var series = this.aggregator.flush();
     if (series.length > 0) {
         debug('Flushing %d metrics to DataDog', series.length);
-        this.reporter.report(series);
+        this.reporter.report(series, onSuccess, onError);
     } else {
         debug('Nothing to flush');
     }


### PR DESCRIPTION
Adds a way to flush metrics e.g. before quitting the application.