### PR TITLE
Support default tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ var metricsLogger = new metrics.BufferedMetricsLogger({
     apiKey: 'TESTKEY',
     host: 'myhost',
     prefix: 'myapp.',
-    flushIntervalSeconds: 15
+    flushIntervalSeconds: 15,
+    defaultTags: ['env:staging', 'region:us-east-1']
 });
 metricsLogger.gauge('mygauge', 42);
 ```
@@ -116,6 +117,8 @@ Where `options` is an object and can contain the following:
 * `appKey`: Sets the DataDog APP key. (optional)
     * It's usually best to keep this in an environment variable.
       Datadog-metrics looks for the APP key in `DATADOG_APP_KEY` by default.
+* `defaultTags`: Default tags used for all metric reporting. (optional)
+    * Set tags that are common to all metrics.
 
 
 Example:
@@ -202,6 +205,8 @@ npm test
 
 ## Release History
 
+* 0.4.0
+    * ADD: Initialize with a default set of tags
 * 0.3.0
     * FIX: Don't overwrite metrics with the same key but different tags when aggregating them (Thanks @akrylysov and @RavivIsraeli!)
     * ADD: Add success/error callbacks to `metrics.flush()` (Thanks @akrylysov!)

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var sharedLogger = null;
 //     - appKey: DataDog APP key
 //     - host: Default host for all reported metrics
 //     - prefix: Default key prefix for all metrics
+//     - defaultTags: Common tags for all metrics
 //     - flushIntervalSeconds:
 //
 // You can also use it to override (dependency-inject) the aggregator

--- a/lib/aggregators.js
+++ b/lib/aggregators.js
@@ -4,8 +4,9 @@
 // --- Aggregator
 //
 
-function Aggregator(opts) {
+function Aggregator(defaultTags) {
     this.buffer = {};
+    this.defaultTags = defaultTags || [];
 }
 
 Aggregator.prototype.makeBufferKey = function(key, tags) {
@@ -27,6 +28,13 @@ Aggregator.prototype.flush = function() {
     for (var key in this.buffer) {
         if (this.buffer.hasOwnProperty(key)) {
             series = series.concat(this.buffer[key].flush());
+        }
+    }
+
+    // Concat default tags
+    if (this.defaultTags) {
+        for (var i = 0; i < series.length; i++) {
+            series[i].tags = this.defaultTags.concat(series[i].tags);
         }
     }
 

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -36,7 +36,7 @@ var Histogram = require('./metrics').Histogram;
 //     - reporter: a Reporter instance
 //
 function BufferedMetricsLogger(opts) {
-    this.aggregator = opts.aggregator || new Aggregator();
+    this.aggregator = opts.aggregator || new Aggregator(opts.defaultTags);
     this.reporter = opts.reporter || new DataDogReporter(opts.apiKey, opts.appKey);
     this.host = opts.host;
     this.prefix = opts.prefix || '';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-metrics",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Buffered metrics reporting via the DataDog HTTP API",
   "main": "index.js",
   "repository": {

--- a/test/aggregators_tests.js
+++ b/test/aggregators_tests.js
@@ -73,5 +73,16 @@ describe('Aggregator', function() {
         f.should.have.length(1);
         f[0].should.have.deep.property('points[0][1]', 2);
     });
+
+    it('should report default tags', function() {
+        var defaultTags = ['one', 'two'];
+        var agg = new aggregators.Aggregator(defaultTags);
+        agg.addPoint(metrics.Counter, 'test.mykey', 2, ['mytag1'], 'myhost');
+        agg.addPoint(metrics.Counter, 'test.mykey', 3, ['mytag2'], 'myhost');
+        var f = agg.flush();
+        f.should.have.length(2);
+        f[0].should.have.deep.property('tags[0]', 'one');
+        f[1].should.have.deep.property('tags[1]', 'two');
+    });
 });
 

--- a/test/loggers_tests.js
+++ b/test/loggers_tests.js
@@ -77,4 +77,12 @@ describe('BufferedMetricsLogger', function() {
         l.increment('test.counter', 23);
         l.histogram('test.histogram', 23);
     });
+
+    it('should allow setting default tags', function() {
+        var l = new BufferedMetricsLogger({
+            reporter: new reporters.NullReporter(),
+            defaultTags: ['one', 'two']
+        });
+        l.aggregator.defaultTags.should.deep.equal(['one', 'two']);
+    });
 });


### PR DESCRIPTION
``` javascript
var metrics = new metrics.BufferedMetricsLogger({
    // ...
    defaultTags: ['one', 'two']
});
metrics.increment('my_counter', 1, ['three']);
// Reports tags: one, two, three
```
