### PR TITLE
update metric type `counter` to `count` as `counter` is being depreca…

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -96,7 +96,7 @@ Counter.prototype.addPoint = function(val, timestampInMillis) {
 };
 
 Counter.prototype.flush = function() {
-    return [this.serializeMetric(this.value, 'counter')];
+    return [this.serializeMetric(this.value, 'count')];
 };
 
 //

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -143,7 +143,7 @@ Histogram.prototype.flush = function() {
         this.serializeMetric(this.min, 'gauge', this.key + '.min'),
         this.serializeMetric(this.max, 'gauge', this.key + '.max'),
         this.serializeMetric(this.sum, 'gauge', this.key + '.sum'),
-        this.serializeMetric(this.count, 'gauge', this.key + '.count'),
+        this.serializeMetric(this.count, 'count', this.key + '.count'),
         this.serializeMetric(this.average(), 'gauge', this.key + '.avg')
     ];
 


### PR DESCRIPTION
…ted.

https://help.datadoghq.com/hc/en-us/articles/206955236-Metric-types-in-Datadog

Metric Types in the web application

In the web app there are 3 metric types: GAUGE, RATE, COUNT (and COUNTER, now deprecated). A metric's type is stored as metrics metadata and is used to determine how a metric is interpreted throughout the app by determining default time aggregation function and as_rate()/as_count() behavior.