### PR TITLE
update metric type `counter` to `count`; `counter` is deprecated

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -96,7 +96,7 @@ Counter.prototype.addPoint = function(val, timestampInMillis) {
 };
 
 Counter.prototype.flush = function() {
-    return [this.serializeMetric(this.value, 'counter')];
+    return [this.serializeMetric(this.value, 'count')];
 };
 
 //

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -143,7 +143,7 @@ Histogram.prototype.flush = function() {
         this.serializeMetric(this.min, 'gauge', this.key + '.min'),
         this.serializeMetric(this.max, 'gauge', this.key + '.max'),
         this.serializeMetric(this.sum, 'gauge', this.key + '.sum'),
-        this.serializeMetric(this.count, 'gauge', this.key + '.count'),
+        this.serializeMetric(this.count, 'count', this.key + '.count'),
         this.serializeMetric(this.average(), 'gauge', this.key + '.avg')
     ];
 

--- a/test/metrics_tests.js
+++ b/test/metrics_tests.js
@@ -78,7 +78,7 @@ describe('Counter', function() {
         f[0].should.have.deep.property('metric', 'the.key');
         f[0].should.have.deep.property('tags[0]', 'mytag');
         f[0].should.have.deep.property('host', 'myhost');
-        f[0].should.have.deep.property('type', 'counter');
+        f[0].should.have.deep.property('type', 'count');
         f[0].should.have.deep.property('points[0][0]', g.timestamp);
         f[0].should.have.deep.property('points[0][1]', 1);
     });
@@ -91,7 +91,7 @@ describe('Counter', function() {
         f[0].should.have.deep.property('metric', 'the.key');
         f[0].should.have.deep.property('tags[0]', 'mytag');
         f[0].should.have.deep.property('host', 'myhost');
-        f[0].should.have.deep.property('type', 'counter');
+        f[0].should.have.deep.property('type', 'count');
         f[0].should.have.deep.property('points[0][0]', 123);
         f[0].should.have.deep.property('points[0][1]', 1);
     });


### PR DESCRIPTION
update metric type `counter` to `count` as `counter` is being deprecated.
https://help.datadoghq.com/hc/en-us/articles/206955236-Metric-types-in-Datadog
```
In the web app there are 3 metric types: GAUGE, RATE, COUNT (and COUNTER, now deprecated).
```

set histogram count to type `count` as well; more precise for the type.