### PR TITLE
Add optional host override to BufferedMetricsLogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ metrics.init({ host: 'myhost', prefix: 'myapp.' });
 
 ### Gauges
 
-`metrics.gauge(key, value[, tags[, timestamp]])`
+`metrics.gauge(key, value[, tags[, timestamp[, host]]]])`
 
 Record the current *value* of a metric. They most recent value in
 a given flush interval will be recorded. Optionally, specify a set of
@@ -138,6 +138,8 @@ tags to associate with the metric. This should be used for sum values
 such as total hard disk space, process uptime, total number of active
 users, or number of rows in a database table. The optional timestamp
 is in milliseconds since 1 Jan 1970 00:00:00 UTC, e.g. from `Date.now()`.
+An optional host can be provided to override the value specified in the
+initialization options.
 
 Example:
 
@@ -147,31 +149,34 @@ metrics.gauge('test.mem_free', 23);
 
 ### Counters
 
-`metrics.increment(key[, value[, tags[, timestamp]]])`
+`metrics.increment(key[, value[, tags[, timestamp[, host]]]])`
 
 Increment the counter by the given *value* (or `1` by default). Optionally,
 specify a list of *tags* to associate with the metric. This is useful for
 counting things such as incrementing a counter each time a page is requested.
 The optional timestamp is in milliseconds since 1 Jan 1970 00:00:00 UTC,
-e.g. from `Date.now()`.
+e.g. from `Date.now()`. An optional host can be provided to override the
+value specified in the initialization options.
 
 Example:
 
 ```js
 metrics.increment('test.requests_served');
 metrics.increment('test.awesomeness_factor', 10);
+metrics.increment('test.awesomeness_factor', 10, ['tag:value'], 1510958499882, 'server.mydomain.com');
 ```
 
 ### Histograms
 
-`metrics.histogram(key, value[, tags[, timestamp]])`
+`metrics.histogram(key, value[, tags[, timestamp[, host]]]])`
 
 Sample a histogram value. Histograms will produce metrics that
 describe the distribution of the recorded values, namely the minimum,
 maximum, average, count and the 75th, 85th, 95th and 99th percentiles.
 Optionally, specify a list of *tags* to associate with the metric.
 The optional timestamp is in milliseconds since 1 Jan 1970 00:00:00 UTC,
-e.g. from `Date.now()`.
+e.g. from `Date.now()`.  An optional host can be provided to override
+the value specified in the initialization options
 
 Example:
 

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -63,20 +63,20 @@ function BufferedMetricsLogger(opts) {
 }
 
 // Prepend the global key prefix and set the default host.
-BufferedMetricsLogger.prototype.addPoint = function(Type, key, value, tags, timestampInMillis) {
-    this.aggregator.addPoint(Type, this.prefix + key, value, tags, this.host, timestampInMillis);
+BufferedMetricsLogger.prototype.addPoint = function(Type, key, value, tags, timestampInMillis, host) {
+    this.aggregator.addPoint(Type, this.prefix + key, value, tags, host || this.host, timestampInMillis);
 };
 
-BufferedMetricsLogger.prototype.gauge = function(key, value, tags, timestampInMillis) {
-    this.addPoint(Gauge, key, value, tags, timestampInMillis);
+BufferedMetricsLogger.prototype.gauge = function(key, value, tags, timestampInMillis, host) {
+    this.addPoint(Gauge, key, value, tags, timestampInMillis, host);
 };
 
-BufferedMetricsLogger.prototype.increment = function(key, value, tags, timestampInMillis) {
-    this.addPoint(Counter, key, value || 1, tags, timestampInMillis);
+BufferedMetricsLogger.prototype.increment = function(key, value, tags, timestampInMillis, host) {
+    this.addPoint(Counter, key, value || 1, tags, timestampInMillis, host);
 };
 
-BufferedMetricsLogger.prototype.histogram = function(key, value, tags, timestampInMillis) {
-    this.addPoint(Histogram, key, value, tags, timestampInMillis);
+BufferedMetricsLogger.prototype.histogram = function(key, value, tags, timestampInMillis, host) {
+    this.addPoint(Histogram, key, value, tags, timestampInMillis, host);
 };
 
 BufferedMetricsLogger.prototype.flush = function(onSuccess, onError) {

--- a/test/loggers_tests.js
+++ b/test/loggers_tests.js
@@ -81,6 +81,21 @@ describe('BufferedMetricsLogger', function() {
         l.histogram('test.histogram', 23);
     });
 
+    it('should allow setting a host override', function() {
+        var l = new BufferedMetricsLogger({
+            reporter: new reporters.NullReporter(),
+            host: 'myhost'
+        });
+        l.aggregator = {
+            addPoint: function(Type, key, value, tags, host) {
+                host.should.equal('overrideHost');
+            }
+        };
+        l.gauge('test.gauge', 23, null, null, 'overrideHost');
+        l.increment('test.counter', 23, null, null, 'overrideHost');
+        l.histogram('test.histogram', 23, null, null, 'overrideHost');
+    });
+
     it('should allow setting a default key prefix', function() {
         var l = new BufferedMetricsLogger({
             reporter: new reporters.NullReporter(),


### PR DESCRIPTION
Extend the BufferedMetricsLogger to support an optional host param. If no host is provided fall back to the value provided during initialization.