### PR TITLE
Update version of dogapi dependency to 2.8.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "debug": "3.1.0",
-    "dogapi": "1.1.0"
+    "dogapi": "2.8.3"
   }
 }


### PR DESCRIPTION
dogapi added a 30-second timeout to its HTTPS requests, which lets clients handle dropped calls more gracefully.
