### PR TITLE
Extending initialization to support EU realm

### DIFF
--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -21,16 +21,17 @@ NullReporter.prototype.report = function(series, onSuccess, onError) {
 // DataDogReporter
 //
 
-function DataDogReporter(apiKey, appKey, agent) {
+function DataDogReporter(apiKey, appKey, agent, apiHost) {
     apiKey = apiKey || process.env.DATADOG_API_KEY;
     appKey = appKey || process.env.DATADOG_APP_KEY;
+    apiHost = apiHost || process.env.DATADOG_API_HOST;
 
     if (!apiKey) {
         throw new Error('DATADOG_API_KEY environment variable not set');
     }
 
     // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
-    dogapi.initialize({api_key: apiKey, app_key: appKey, proxy_agent: agent });
+    dogapi.initialize({api_key: apiKey, app_key: appKey, proxy_agent: agent, api_host: apiHost});
     // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
 }
 


### PR DESCRIPTION
Extended the initialization of the dogapi to support other endpoints such as the EU API, given that the dogapi already supports this. https://brettlangdon.github.io/node-dogapi/#dogapi-initialize
Also added the parameter and env options.