### PR TITLE
Consistent check of param onSuccess

### DIFF
--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -13,7 +13,9 @@ function NullReporter(apiKey, appKey) {
 
 NullReporter.prototype.report = function(series, onSuccess, onError) {
     // Do nothing.
-    onSuccess();
+    if (typeof onSuccess === 'function') {
+        onSuccess();
+    }
 };
 
 


### PR DESCRIPTION
DataDogReporter always check if onSuccess is method, NullReporter doesn't.