### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,3 @@ jobs:
 
     - name: "Check codestyle"
       script: npm run check-codestyle
-
-sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: node_js
 node_js:
     - "stable"
-    - "5"
     - "4"
     - "0.12"
+jobs:
+  include:
+    # With Node.js 5, we need a version of npm higher than the default from NVM
+    # Otherwise we hit https://github.com/npm/cli/issues/681
+    - name: "Node.js 5"
+      node_js: "5"
+      before_install:
+        - npm i -g npm@4.6.1
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,8 @@ jobs:
       node_js: "5"
       before_install:
         - npm i -g npm@4.6.1
+
+    - name: "Check codestyle"
+      script: npm run check-codestyle
+
 sudo: false

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "url": "https://github.com/dbader/node-datadog-metrics/issues"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --reporter spec && ./node_modules/.bin/jshint --reporter node_modules/jshint-stylish-ex/stylish.js *.js ./lib/*.js ./test/*.js && ./node_modules/.bin/jscs --config .jscsrc *.js ./lib/*.js ./test/*.js"
+    "test": "./node_modules/.bin/mocha --reporter spec",
+    "check-codestyle": "./node_modules/.bin/jshint --reporter node_modules/jshint-stylish-ex/stylish.js *.js ./lib/*.js ./test/*.js && ./node_modules/.bin/jscs --config .jscsrc *.js ./lib/*.js ./test/*.js"
   },
   "keywords": [
     "datadog",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "url": "https://github.com/dbader/node-datadog-metrics/issues"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --reporter spec",
-    "check-codestyle": "./node_modules/.bin/jshint --reporter node_modules/jshint-stylish-ex/stylish.js *.js ./lib/*.js ./test/*.js && ./node_modules/.bin/jscs --config .jscsrc *.js ./lib/*.js ./test/*.js"
+    "test": "mocha --reporter spec",
+    "check-codestyle": "jshint --reporter node_modules/jshint-stylish-ex/stylish.js *.js ./lib/*.js ./test/*.js && jscs --config .jscsrc *.js ./lib/*.js ./test/*.js"
   },
   "keywords": [
     "datadog",


### PR DESCRIPTION
Hi, here's a set of changes that should fix the failing Travis build:
- It looks like the [Node 5 job](https://travis-ci.org/github/dbader/node-datadog-metrics/jobs/756115077) is hitting [this issue](https://github.com/npm/cli/issues/681). Forcing this job to use a later version of npm than the one automatically provided by nvm should fix the `npm install` step
- The [Node 4 job](https://travis-ci.org/github/dbader/node-datadog-metrics/jobs/756115078) and [Node 0.12 job](https://travis-ci.org/github/dbader/node-datadog-metrics/jobs/756115079) are failing because of internal errors of the JSCS linter. I think that running the linter only once with the latest version of Node is enough to enforce the codestyle, so https://github.com/dbader/node-datadog-metrics/commit/accf1ceed563d0e366ad6d25afdee750f4295bc7 moves it to a separate job
- Remove the deprecated `sudo: false` from the `.travis.yml` (as encouraged [here](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration))