### PR TITLE
Only call `unref()` when it exists

### DIFF
--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -56,7 +56,7 @@ function BufferedMetricsLogger(opts) {
             const interval = self.flushIntervalSeconds * 1000;
             const tid = setTimeout(autoFlushCallback, interval);
             // Let the event loop exit if this is the only active timer.
-            tid.unref();
+            if (tid.unref) tid.unref();
         }
     };
 


### PR DESCRIPTION
Not all JavaScript environments have an `.unref()` function on timers. This guards the one usage of `.unref()` so as not to cause exceptions in environments that do not have it.

It solves the one issue explicitly called out in #43, but I didn’t actually do any testing with browsers, and don’t know if there might be other barriers to browser-based usage yet to be solved.