### PR TITLE
Publicly export built-in reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,23 @@ Where `options` is an object and can contain the following:
       Datadog-metrics looks for the APP key in `DATADOG_APP_KEY` by default.
 * `defaultTags`: Default tags used for all metric reporting. (optional)
     * Set tags that are common to all metrics.
+* `reporter`: An object that actually sends the buffered metrics. (optional)
+    * There are two built-in reporters you can use:
+        1. `reporters.DataDogReporter` sends metrics to DataDog’s API, and is
+           the default.
+        2. `reporters.NullReporter` throws the metrics away. It’s useful for
+           tests or temporarily disabling your metrics.
 
 Example:
 
 ```js
 metrics.init({ host: 'myhost', prefix: 'myapp.' });
+```
+
+Disabling metrics using `NullReporter`:
+
+```js
+metrics.init({ host: 'myhost', reporter: metrics.NullReporter() });
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const loggers = require('./lib/loggers');
+const reporters = require('./lib/reporters');
 
 let sharedLogger = null;
 
@@ -45,5 +46,7 @@ module.exports = {
     histogram: callOnSharedLogger.bind(undefined, 'histogram'),
     distribution: callOnSharedLogger.bind(undefined, 'distribution'),
 
-    BufferedMetricsLogger: loggers.BufferedMetricsLogger
+    BufferedMetricsLogger: loggers.BufferedMetricsLogger,
+
+    reporters: reporters
 };

--- a/test/module_tests.js
+++ b/test/module_tests.js
@@ -77,4 +77,9 @@ describe('datadog-metrics', function() {
         metrics.histogram('test.histogram', 23);
         delete process.env.DATADOG_API_KEY;
     });
+
+    it('should publicly export built-in reporters', function() {
+        metrics.reporters.should.have.property('DataDogReporter', reporters.DataDogReporter);
+        metrics.reporters.should.have.property('NullReporter', reporters.NullReporter);
+    })
 });


### PR DESCRIPTION
This lets people use the built-in `NullReporter` for tests or disabling metrics. I took the route of exposing the entire `reporters` module simplicity and consistency, although it shouldn’t actually be necessary for anyone to ever explicitly use `reporters.DataDogReporter`.

Fixes #67.