### PR TITLE
Add GitHub actions workflow for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+on:
+  pull_request: {}
+  push: {}
+
+name: Continuous Integration
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version: [12, 14, 16, 18]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: 'npm'
+          cache-dependency-path: '**/package.json'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run loader tests
+        run: |
+          npm test


### PR DESCRIPTION
When submitting some other pull requests, I noticed the tests don’t run or show up as checks. This adds a quick GitHub actions workflow to run them automatically (in LTS versions of Node >= 12) and give maintainers a quick hint about whether a pull request is OK. (Obviously it’s not a complete check, but this is a lot better than flying totally blind!)

I also noticed that the `package.json` file includes the JSCS and JSHint for linting, but didn’t set the workflow up to use them:
- JSCS is no longer maintained (it merged with ESLint).
- JSHint doesn’t actually work —  its defaults are geared for ES5 and earlier, and there’s not config file for the features this codebase now uses. It logs lots of errors if you try and run it.

It might be worth setting up ESLint and/or Prettier for this repo in the future, but for now I just left linting alone.