### PR TITLE
Use ranges for dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "mocha": "2.4.5"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "1.3.0",
-    "debug": "3.1.0"
+    "@datadog/datadog-api-client": "^1.3.0",
+    "debug": "^4.1.0"
   }
 }


### PR DESCRIPTION
Both dependencies of this package used to exact dependencies, which can result in a lot of redundancy if a consumer of this package has other dependencies that also use `debug` or `@datadog/datadog-api-client`. Instead, we now use "compatible with" ranges to let consumers use any version of our dependencies that should work with our code.

This also updates `debug` to the current major release. (This declares anything compatible with 4.1, not 4.0, since 4.1 has an important fix.)

This *doesn’t* address development dependencies, which I’ll see about updating in a separate PR.