### PR TITLE
Normalize new syntax from recent PRs

### DIFF
--- a/lib/aggregators.js
+++ b/lib/aggregators.js
@@ -26,13 +26,13 @@ Aggregator.prototype.addPoint = function(Type, key, value, tags, host, timestamp
 Aggregator.prototype.flush = function() {
     let series = [];
     for (const item of Object.values(this.buffer)) {
-        series = series.concat(item.flush());
+        series.push(...item.flush());
     }
 
-    // Concat default tags
+    // Add default tags
     if (this.defaultTags) {
         for (const metric of series) {
-            metric.tags = this.defaultTags.concat(metric.tags);
+            metric.tags.unshift(...this.defaultTags);
         }
     }
 

--- a/lib/aggregators.js
+++ b/lib/aggregators.js
@@ -25,16 +25,14 @@ Aggregator.prototype.addPoint = function(Type, key, value, tags, host, timestamp
 
 Aggregator.prototype.flush = function() {
     let series = [];
-    for (let key in this.buffer) {
-        if (this.buffer.hasOwnProperty(key)) {
-            series = series.concat(this.buffer[key].flush());
-        }
+    for (const item of Object.values(this.buffer)) {
+        series = series.concat(item.flush());
     }
 
     // Concat default tags
     if (this.defaultTags) {
-        for (let i = 0; i < series.length; i++) {
-            series[i].tags = this.defaultTags.concat(series[i].tags);
+        for (const metric of series) {
+            metric.tags = this.defaultTags.concat(metric.tags);
         }
     }
 

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -50,11 +50,10 @@ function BufferedMetricsLogger(opts) {
         debug('Auto-flushing is disabled');
     }
 
-    const self = this;
-    const autoFlushCallback = function() {
-        self.flush();
-        if (self.flushIntervalSeconds) {
-            const interval = self.flushIntervalSeconds * 1000;
+    const autoFlushCallback = () => {
+        this.flush();
+        if (this.flushIntervalSeconds) {
+            const interval = this.flushIntervalSeconds * 1000;
             const tid = setTimeout(autoFlushCallback, interval);
             // Let the event loop exit if this is the only active timer.
             if (tid.unref) tid.unref();

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -142,19 +142,19 @@ Histogram.prototype.addPoint = function(val, timestampInMillis) {
 
 Histogram.prototype.flush = function () {
     let points = [];
-    if (this.aggregates.indexOf('min') !== -1) {
+    if (this.aggregates.includes('min')) {
       points.push(this.serializeMetric(this.min, 'gauge', this.key + '.min'));
     }
-    if (this.aggregates.indexOf('max') !== -1) {
+    if (this.aggregates.includes('max')) {
       points.push(this.serializeMetric(this.max, 'gauge', this.key + '.max'));
     }
-    if (this.aggregates.indexOf('sum') !== -1) {
+    if (this.aggregates.includes('sum')) {
       points.push(this.serializeMetric(this.sum, 'gauge', this.key + '.sum'));
     }
-    if (this.aggregates.indexOf('count') !== -1) {
+    if (this.aggregates.includes('count')) {
       points.push(this.serializeMetric(this.count, 'count', this.key + '.count'));
     }
-    if (this.aggregates.indexOf('avg') !== -1) {
+    if (this.aggregates.includes('avg')) {
       points.push(
         this.serializeMetric(this.average(), 'gauge', this.key + '.avg')
       );

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -162,10 +162,7 @@ Histogram.prototype.flush = function () {
   
     // Careful, calling samples.sort() will sort alphabetically giving
     // the wrong result. We must define our own compare function.
-    const numericalSortAscending = function (a, b) {
-      return a - b;
-    };
-    this.samples.sort(numericalSortAscending);
+    this.samples.sort((a, b) => a - b);
 
     if (this.aggregates.includes('median')) {
         points.push(
@@ -173,13 +170,11 @@ Histogram.prototype.flush = function () {
         );
     }
   
-    const calcPercentile = function (p) {
+    const percentiles = this.percentiles.map((p) => {
         const val = this.samples[Math.round(p * this.samples.length) - 1];
         const suffix = '.' + Math.floor(p * 100) + 'percentile';
         return this.serializeMetric(val, 'gauge', this.key + suffix);
-    };
-  
-    const percentiles = this.percentiles.map(calcPercentile, this);
+    });
     return points.concat(percentiles);
 };
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -38,7 +38,7 @@ Metric.prototype.serializeMetric = function(value, type, key) {
         points: [[this.timestamp, value]],
         type: type,
         host: this.host,
-        tags: this.tags
+        tags: this.tags.slice()
     };
 };
 
@@ -243,7 +243,7 @@ Distribution.prototype.serializeMetric = function(points, type, key) {
         points: points || this.points,
         type: type,
         host: this.host,
-        tags: this.tags
+        tags: this.tags.slice()
     };
 };
 

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -1,7 +1,6 @@
 'use strict';
 const debug = require('debug')('metrics');
 const datadogApiClient = require('@datadog/datadog-api-client');
-const callbackify = require('util').callbackify;
 let metricsApi;
 
 //
@@ -41,20 +40,6 @@ function DataDogReporter(apiKey, appKey) {
 }
 
 DataDogReporter.prototype.report = function(series, onSuccess, onError) {
-    const callback = function(err, res) {
-        if (err === null) {
-            debug('sent metrics successfully');
-            if (typeof onSuccess === 'function') {
-                onSuccess();
-            }
-        } else {
-            debug('ERROR: failed to send metrics %s (err=%s)', res, err);
-            if (typeof onError === 'function') {
-                onError(err, res);
-            }
-        }
-    };
-
     if (debug.enabled) {
         // Only call stringify when debugging.
         debug('Calling report with %s', JSON.stringify(series));
@@ -83,8 +68,20 @@ DataDogReporter.prototype.report = function(series, onSuccess, onError) {
             body: { series: distributions }
         }));
     }
-    
-    callbackify(() => Promise.all(submissions))(callback);
+
+    Promise.all(submissions)
+        .then(() => {
+            debug('sent metrics successfully');
+            if (typeof onSuccess === 'function') {
+                onSuccess();
+            }
+        })
+        .catch((error) => {
+            debug('ERROR: failed to send metrics %s (err=%s)', res, err);
+            if (typeof onError === 'function') {
+                onError(err);
+            }
+        });
 };
 
 module.exports = {

--- a/test/aggregators_tests.js
+++ b/test/aggregators_tests.js
@@ -88,8 +88,19 @@ describe('Aggregator', function() {
         agg.addPoint(metrics.Counter, 'test.mykey', 3, ['mytag2'], 'myhost');
         var f = agg.flush();
         f.should.have.length(2);
-        f[0].should.have.deep.property('tags[0]', 'one');
-        f[1].should.have.deep.property('tags[1]', 'two');
+        f[0].tags.should.eql(['one', 'two', 'mytag1']);
+        f[1].tags.should.eql(['one', 'two', 'mytag2']);
+    });
+
+    it('should add default tags for compound metrics', function() {
+        var defaultTags = ['one', 'two'];
+        var agg = new aggregators.Aggregator(defaultTags);
+        agg.addPoint(metrics.Histogram, 'test.mykey', 2, ['mytag1'], 'myhost');
+        var f = agg.flush();
+
+        for (const flushed of f) {
+            flushed.tags.should.eql(['one', 'two', 'mytag1']);
+        }
     });
 });
 

--- a/test/loggers_tests.js
+++ b/test/loggers_tests.js
@@ -16,7 +16,7 @@ describe('BufferedMetricsLogger', function() {
             reporter: new reporters.NullReporter()
         });
         l.aggregator = {
-            addPoint: function(Type, key, value, tags, host, timestampInMillis) {
+            addPoint (Type, key, value, tags, host, timestampInMillis) {
                 key.should.equal('test.gauge');
                 value.should.equal(23);
                 tags.should.eql(['a:a']);
@@ -32,7 +32,7 @@ describe('BufferedMetricsLogger', function() {
         });
 
         l.aggregator = {
-            addPoint: function(Type, key, value, tags, host) {
+            addPoint (Type, key, value, tags, host) {
                 key.should.equal('test.counter');
                 value.should.equal(1);
             }
@@ -40,7 +40,7 @@ describe('BufferedMetricsLogger', function() {
         l.increment('test.counter');
 
         l.aggregator = {
-            addPoint: function(Type, key, value, tags, host) {
+            addPoint (Type, key, value, tags, host) {
                 key.should.equal('test.counter2');
                 value.should.equal(0);
             }
@@ -48,7 +48,7 @@ describe('BufferedMetricsLogger', function() {
         l.increment('test.counter2', 0);
 
         l.aggregator = {
-            addPoint: function(Type, key, value, tags, host) {
+            addPoint (Type, key, value, tags, host) {
                 key.should.equal('test.counter3');
                 value.should.equal(1);
             }
@@ -56,7 +56,7 @@ describe('BufferedMetricsLogger', function() {
         l.increment('test.counter3', null);
 
         l.aggregator = {
-            addPoint: function(Type, key, value, tags, host, timestampInMillis) {
+            addPoint (Type, key, value, tags, host, timestampInMillis) {
                 key.should.equal('test.counter4');
                 value.should.equal(23);
                 tags.should.eql(['z:z', 'a:a']);
@@ -71,7 +71,7 @@ describe('BufferedMetricsLogger', function() {
             reporter: new reporters.NullReporter()
         });
         l.aggregator = {
-            addPoint: function(Type, key, value, tags, host, timestampInMillis) {
+            addPoint (Type, key, value, tags, host, timestampInMillis) {
                 key.should.equal('test.histogram');
                 value.should.equal(23);
                 tags.should.eql(['a:a']);
@@ -87,7 +87,7 @@ describe('BufferedMetricsLogger', function() {
             host: 'myhost'
         });
         l.aggregator = {
-            addPoint: function(Type, key, value, tags, host) {
+            addPoint (Type, key, value, tags, host) {
                 host.should.equal('myhost');
             }
         };
@@ -102,7 +102,7 @@ describe('BufferedMetricsLogger', function() {
             prefix: 'mynamespace.'
         });
         l.aggregator = {
-            addPoint: function(Type, key, value, tags, host) {
+            addPoint (Type, key, value, tags, host) {
                 key.should.startWith('mynamespace.test.');
             }
         };

--- a/test/module_tests.js
+++ b/test/module_tests.js
@@ -29,7 +29,7 @@ describe('datadog-metrics', function() {
         metrics.init({
             flushIntervalSeconds: 0,
             reporter: {
-                report: function(series, onSuccess, onError) {
+                report (series, onSuccess, onError) {
                     series.should.have.length(12); // 3 + 9 for the histogram.
                     series[0].should.have.deep.property('points[0][1]', 23);
                     series[0].should.have.deep.property('metric', 'test.gauge');
@@ -51,7 +51,7 @@ describe('datadog-metrics', function() {
         metrics.init({
             flushIntervalSeconds: 0,
             reporter: {
-                report: function(series, onSuccess, onError) {
+                report (series, onSuccess, onError) {
                     series.should.have.length(2);
                     series[0].should.have.deep.property('points[0][1]', 1);
                     series[0].should.have.deep.property('metric', 'test.gauge');


### PR DESCRIPTION
This is a quick pass at updating some of the syntax to match newer language features I used in recent PRs (#69, #71):
- Array `.includes(x)` instead of `.indexOf(x) !== -1`.
- `for...of` loops.
- Rest/spread (`...`) syntax, and using that to modify arrays (where it’s safe!) instead of calling `concat()`, which can be slower and more memory-intense.
- Don’t use `callbackify` where not necessary.
- Arrow functions (where they do something useful).
- Newer style for functions in object literals:

    ```js
    const object = {
      someFunction (arg1, arg2) {
        // ...function body here...
      }
    };
    // is equivalent to:
    const object = {
      someFunction: function someFunction (arg1, arg2) {
        // ...function body here...
      }
    };

**This does not** cover larger syntactical/structural changes, like:
- `class` syntax.
- Promises instead of callbacks.
- `async`/`await` keywords.

Those are probably better suited to a separate PR, but I can also do them here if we think it makes more sense.