### PR TITLE
Fix the broken `apiHost` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you need even more control you can create one or more `BufferedMetricsLogger`
 ```js
 var metrics = require('datadog-metrics');
 var metricsLogger = new metrics.BufferedMetricsLogger({
-    apiHost: 'app.datadoghq.eu',
+    apiHost: 'datadoghq.eu',
     apiKey: 'TESTKEY',
     host: 'myhost',
     prefix: 'myapp.',
@@ -112,8 +112,11 @@ Where `options` is an object and can contain the following:
 * `flushIntervalSeconds`: How often to send metrics to Datadog. (optional)
     * This defaults to 15 seconds. Set it to 0 to disable auto-flushing which
       means you must call `flush()` manually.
-* `apiHost`: Sets the Datadog API host. (optional)
-    * Defaults to `app.datadoghq.com`.
+* `apiHost`: Sets the Datadog API host (also called "site" in Datadog docs).
+    (optional)
+    * Defaults to `datadoghq.com`.
+    * See more details on setting your site at:
+        https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
 * `apiKey`: Sets the Datadog API key. (optional)
     * It's usually best to keep this in an environment variable.
       Datadog-metrics looks for the API key in `DATADOG_API_KEY` by default.

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -28,7 +28,7 @@ const Distribution = require('./metrics').Distribution;
 //     - appKey: DataDog APP key
 //     - host: Default host for all reported metrics
 //     - prefix: Default key prefix for all metrics
-//     - agent: a https agent, passed as dogapi's proxy_agent
+//     - apiHost: Datadog API host (also called "site" in Datadog docs)
 //     - flushIntervalSeconds:
 //
 // You can also use it to override (dependency-inject) the aggregator
@@ -39,7 +39,7 @@ const Distribution = require('./metrics').Distribution;
 //
 function BufferedMetricsLogger(opts) {
     this.aggregator = opts.aggregator || new Aggregator(opts.defaultTags);
-    this.reporter = opts.reporter || new DataDogReporter(opts.apiKey, opts.appKey, opts.agent, opts.apiHost);
+    this.reporter = opts.reporter || new DataDogReporter(opts.apiKey, opts.appKey, opts.apiHost);
     this.host = opts.host;
     this.prefix = opts.prefix || '';
     this.flushIntervalSeconds = opts.flushIntervalSeconds;

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -23,9 +23,10 @@ NullReporter.prototype.report = function(series, onSuccess) {
 // DataDogReporter
 //
 
-function DataDogReporter(apiKey, appKey) {
+function DataDogReporter(apiKey, appKey, apiHost) {
     apiKey = apiKey || process.env.DATADOG_API_KEY;
     appKey = appKey || process.env.DATADOG_APP_KEY;
+    this.apiHost = apiHost || process.env.DATADOG_API_HOST;
 
     if (!apiKey) {
         throw new Error('DATADOG_API_KEY environment variable not set');
@@ -37,6 +38,15 @@ function DataDogReporter(apiKey, appKey) {
             appKeyAuth: appKey
         }
     });
+    if (this.apiHost) {
+        // Strip leading `app.` from the site in case someone copy/pasted the
+        // URL from their web browser. More details on correct configuration:
+        // https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
+        this.apiHost = apiHost.replace(/^app\./i, '');
+        datadogApiClient.client.setServerVariables(configuration, {
+            site: this.apiHost
+        });
+    }
     metricsApi = new datadogApiClient.v1.MetricsApi(configuration);
 }
 

--- a/test/loggers_tests.js
+++ b/test/loggers_tests.js
@@ -118,4 +118,20 @@ describe('BufferedMetricsLogger', function() {
         });
         l.aggregator.defaultTags.should.deep.equal(['one', 'two']);
     });
+
+    it('should allow setting apiHost/site', function() {
+        var l = new BufferedMetricsLogger({
+            apiKey: 'abc123',
+            apiHost: 'datadoghq.eu'
+        });
+        l.reporter.should.have.property('apiHost', 'datadoghq.eu');
+    });
+
+    it('should allow setting apiHost/site with "app.*" URLs', function() {
+        var l = new BufferedMetricsLogger({
+            apiKey: 'abc123',
+            apiHost: 'app.datadoghq.eu'
+        });
+        l.reporter.should.have.property('apiHost', 'datadoghq.eu');
+    });
 });


### PR DESCRIPTION
It looks like the `apiHost` option was added in #50, had some fixes committed directly to the main branch later (?), and then was broken in #62 when the underlying Datadog client implementation was changed. This fixes it, and resolves #42.

The `agent` option was also broken in #62, but the PR discussion makes that look intentional (while there are no notes about breaking `apiHost`). However, only part of the implementation awas removed and it was still documented in some spots. I also cleaned all that out here.

I think it might also be a good idea to *deprecate* this option name and change it to `site`, since that’s what this is called throughout Datadog’s official docs.