### PR TITLE
Update linters and turn them on in CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+[*]
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_size = 4
+
+[*.js]
+max_line_length = 110
+
+[package*.json]
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,22 @@ jobs:
       - name: Run loader tests
         run: |
           npm test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: '**/package.json'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run linter
+        run: |
+          npm run check-codestyle

--- a/.jscsrc
+++ b/.jscsrc
@@ -14,6 +14,8 @@
   "requireSpaceBeforeBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", "<", ">=", "<="],
   "requireSpacesInConditionalExpression": true,
   "requireSpacesInFunctionExpression": { "beforeOpeningCurlyBrace": true },
+  "requireSpacesInsideImportedObjectBraces": true,
+  "requireUseStrict": true,
   "validateIndentation": 4,
   "validateLineBreaks": "LF",
   "validateQuoteMarks": "'"

--- a/.jshintrc
+++ b/.jshintrc
@@ -5,6 +5,8 @@
     // Environments
     // ------------
     //
+    // ES10 (2019) roughly matches Node.js v12.
+    "esversion": 10,
     "predef": [ ],
     "globals": {
     },
@@ -61,6 +63,8 @@
     "maxcomplexity": false,
 
     "maxlen": 110,
+
+    "varstmt": true,
 
     // Relaxing options
     // ----------------

--- a/examples/metrics.js
+++ b/examples/metrics.js
@@ -13,4 +13,3 @@ metrics.flush = promisfy(metrics.flush)
 
     await metrics.flush();
 })();
-

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -143,23 +143,23 @@ Histogram.prototype.addPoint = function(val, timestampInMillis) {
 Histogram.prototype.flush = function () {
     let points = [];
     if (this.aggregates.includes('min')) {
-      points.push(this.serializeMetric(this.min, 'gauge', this.key + '.min'));
+        points.push(this.serializeMetric(this.min, 'gauge', this.key + '.min'));
     }
     if (this.aggregates.includes('max')) {
-      points.push(this.serializeMetric(this.max, 'gauge', this.key + '.max'));
+        points.push(this.serializeMetric(this.max, 'gauge', this.key + '.max'));
     }
     if (this.aggregates.includes('sum')) {
-      points.push(this.serializeMetric(this.sum, 'gauge', this.key + '.sum'));
+        points.push(this.serializeMetric(this.sum, 'gauge', this.key + '.sum'));
     }
     if (this.aggregates.includes('count')) {
-      points.push(this.serializeMetric(this.count, 'count', this.key + '.count'));
+        points.push(this.serializeMetric(this.count, 'count', this.key + '.count'));
     }
     if (this.aggregates.includes('avg')) {
-      points.push(
-        this.serializeMetric(this.average(), 'gauge', this.key + '.avg')
-      );
+        points.push(
+            this.serializeMetric(this.average(), 'gauge', this.key + '.avg')
+        );
     }
-  
+
     // Careful, calling samples.sort() will sort alphabetically giving
     // the wrong result. We must define our own compare function.
     this.samples.sort((a, b) => a - b);
@@ -169,7 +169,7 @@ Histogram.prototype.flush = function () {
             this.serializeMetric(this.median(this.samples), 'gauge', this.key + '.median')
         );
     }
-  
+
     const percentiles = this.percentiles.map((p) => {
         const val = this.samples[Math.round(p * this.samples.length) - 1];
         const suffix = '.' + Math.floor(p * 100) + 'percentile';
@@ -205,13 +205,13 @@ Histogram.prototype.median = function(sortedSamples) {
 // ------------
 // Similar to a histogram, but sends every point to DataDog and does the
 // calculations server-side.
-// 
+//
 // This is higher overhead than Counter or Histogram, but is particularly useful
 // for serverless functions or other environments where many instances of your
 // application may be running concurrently or constantly starting and stopping,
 // and it does not make sense to tag each of them separately so metrics from
 // each don't overwrite each other.
-// 
+//
 // See more documentation of use cases and how distribution work at:
 // https://docs.datadoghq.com/metrics/types/?tab=distribution#metric-types
 //

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -87,9 +87,9 @@ DataDogReporter.prototype.report = function(series, onSuccess, onError) {
             }
         })
         .catch((error) => {
-            debug('ERROR: failed to send metrics %s (err=%s)', res, err);
+            debug('ERROR: failed to send metrics (err=%s)', error);
             if (typeof onError === 'function') {
-                onError(err);
+                onError(error);
             }
         });
 };

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "devDependencies": {
     "chai": "3.5.0",
     "chai-string": "1.1.6",
-    "jscs": "2.9.0",
-    "jshint": "^2.12.0",
+    "jscs": "3.0.7",
+    "jshint": "^2.13.5",
     "jshint-stylish-ex": "0.2.0",
     "mocha": "2.4.5"
   },

--- a/test/aggregators_tests.js
+++ b/test/aggregators_tests.js
@@ -2,101 +2,101 @@
 
 'use strict';
 
-var chai = require('chai');
+const chai = require('chai');
 chai.use(require('chai-string'));
 
-var should = chai.should();
+const should = chai.should();
 
-var aggregators = require('../lib/aggregators');
-var metrics = require('../lib/metrics');
+const aggregators = require('../lib/aggregators');
+const metrics = require('../lib/metrics');
 
 describe('Aggregator', function() {
     it('should flush correctly when empty', function() {
-        var agg = new aggregators.Aggregator();
+        const agg = new aggregators.Aggregator();
         agg.flush().should.have.length(0);
     });
 
     it('should flush a single metric correctly', function() {
-        var agg = new aggregators.Aggregator();
+        const agg = new aggregators.Aggregator();
         agg.addPoint(metrics.Gauge, 'mykey', 23, ['mytag'], 'myhost');
         agg.flush().should.have.length(1);
     });
 
     it('should flush multiple metrics correctly', function() {
-        var agg = new aggregators.Aggregator();
+        const agg = new aggregators.Aggregator();
         agg.addPoint(metrics.Gauge, 'mykey', 23, ['mytag'], 'myhost');
         agg.addPoint(metrics.Gauge, 'mykey2', 42, ['mytag'], 'myhost');
         agg.flush().should.have.length(2);
     });
 
     it('should flush multiple metrics correctly even if only the tag differs', function() {
-        var agg = new aggregators.Aggregator();
+        const agg = new aggregators.Aggregator();
         agg.addPoint(metrics.Gauge, 'mykey', 23, ['mytag1'], 'myhost');
         agg.addPoint(metrics.Gauge, 'mykey', 23, ['mytag2'], 'myhost');
         agg.flush().should.have.length(2);
     });
 
     it('should clear the buffer after flushing', function() {
-        var agg = new aggregators.Aggregator();
+        const agg = new aggregators.Aggregator();
         agg.addPoint(metrics.Gauge, 'mykey', 23, ['mytag'], 'myhost');
         agg.flush().should.have.length(1);
         agg.flush().should.have.length(0);
     });
 
     it('should update an existing metric correctly', function() {
-        var agg = new aggregators.Aggregator();
+        const agg = new aggregators.Aggregator();
         agg.addPoint(metrics.Counter, 'test.mykey', 2, ['mytag'], 'myhost');
         agg.addPoint(metrics.Counter, 'test.mykey', 3, ['mytag'], 'myhost');
-        var f = agg.flush();
+        const f = agg.flush();
         f.should.have.length(1);
         f[0].should.have.deep.property('points[0][1]', 5);
     });
 
     it('should aggregate by key + tag', function() {
-        var agg = new aggregators.Aggregator();
+        const agg = new aggregators.Aggregator();
         agg.addPoint(metrics.Counter, 'test.mykey', 2, ['mytag1'], 'myhost');
         agg.addPoint(metrics.Counter, 'test.mykey', 3, ['mytag2'], 'myhost');
-        var f = agg.flush();
+        const f = agg.flush();
         f.should.have.length(2);
         f[0].should.have.deep.property('points[0][1]', 2);
         f[1].should.have.deep.property('points[0][1]', 3);
     });
 
     it('should treat all empty tags definitions the same', function() {
-        var agg = new aggregators.Aggregator();
+        const agg = new aggregators.Aggregator();
         agg.addPoint(metrics.Gauge, 'noTagsKey', 1, null, 'myhost');
         agg.addPoint(metrics.Gauge, 'noTagsKey', 2, undefined, 'myhost');
         agg.addPoint(metrics.Gauge, 'noTagsKey', 3, [], 'myhost');
-        var f = agg.flush();
+        const f = agg.flush();
         f.should.have.length(1);
         f[0].should.have.deep.property('points[0][1]', 3);
     });
 
     it('should normalize the tag order', function() {
-        var agg = new aggregators.Aggregator();
+        const agg = new aggregators.Aggregator();
         agg.addPoint(metrics.Gauge, 'mykey', 1, ['t1', 't2', 't3'], 'myhost');
         agg.addPoint(metrics.Gauge, 'mykey', 2, ['t3', 't2', 't1'], 'myhost');
-        var f = agg.flush();
+        const f = agg.flush();
         f.should.have.length(1);
         f[0].should.have.deep.property('points[0][1]', 2);
     });
 
     it('should report default tags', function() {
-        var defaultTags = ['one', 'two'];
-        var agg = new aggregators.Aggregator(defaultTags);
+        const defaultTags = ['one', 'two'];
+        const agg = new aggregators.Aggregator(defaultTags);
         agg.addPoint(metrics.Counter, 'test.mykey', 2, ['mytag1'], 'myhost');
         agg.addPoint(metrics.Counter, 'test.mykey', 3, ['mytag2'], 'myhost');
-        var f = agg.flush();
+        const f = agg.flush();
         f.should.have.length(2);
         f[0].tags.should.eql(['one', 'two', 'mytag1']);
         f[1].tags.should.eql(['one', 'two', 'mytag2']);
     });
 
     it('should add default tags for compound metrics', function() {
-        var defaultTags = ['one', 'two'];
-        var agg = new aggregators.Aggregator(defaultTags);
+        const defaultTags = ['one', 'two'];
+        const agg = new aggregators.Aggregator(defaultTags);
         agg.addPoint(metrics.Histogram, 'test.mykey', 2, ['mytag1'], 'myhost');
-        var f = agg.flush();
+        const f = agg.flush();
 
         for (const flushed of f) {
             flushed.tags.should.eql(['one', 'two', 'mytag1']);

--- a/test/loggers_tests.js
+++ b/test/loggers_tests.js
@@ -2,17 +2,17 @@
 
 'use strict';
 
-var chai = require('chai');
+const chai = require('chai');
 chai.use(require('chai-string'));
 
-var should = chai.should();
-var loggers = require('../lib/loggers');
-var reporters = require('../lib/reporters');
-var BufferedMetricsLogger = loggers.BufferedMetricsLogger;
+const should = chai.should();
+const loggers = require('../lib/loggers');
+const reporters = require('../lib/reporters');
+const BufferedMetricsLogger = loggers.BufferedMetricsLogger;
 
 describe('BufferedMetricsLogger', function() {
     it('should have a gauge() metric', function() {
-        var l = new BufferedMetricsLogger({
+        const l = new BufferedMetricsLogger({
             reporter: new reporters.NullReporter()
         });
         l.aggregator = {
@@ -27,7 +27,7 @@ describe('BufferedMetricsLogger', function() {
     });
 
     it('should have an increment() metric', function() {
-        var l = new BufferedMetricsLogger({
+        const l = new BufferedMetricsLogger({
             reporter: new reporters.NullReporter()
         });
 
@@ -67,7 +67,7 @@ describe('BufferedMetricsLogger', function() {
     });
 
     it('should have a histogram() metric', function() {
-        var l = new BufferedMetricsLogger({
+        const l = new BufferedMetricsLogger({
             reporter: new reporters.NullReporter()
         });
         l.aggregator = {
@@ -82,7 +82,7 @@ describe('BufferedMetricsLogger', function() {
     });
 
     it('should allow setting a default host', function() {
-        var l = new BufferedMetricsLogger({
+        const l = new BufferedMetricsLogger({
             reporter: new reporters.NullReporter(),
             host: 'myhost'
         });
@@ -97,7 +97,7 @@ describe('BufferedMetricsLogger', function() {
     });
 
     it('should allow setting a default key prefix', function() {
-        var l = new BufferedMetricsLogger({
+        const l = new BufferedMetricsLogger({
             reporter: new reporters.NullReporter(),
             prefix: 'mynamespace.'
         });
@@ -112,7 +112,7 @@ describe('BufferedMetricsLogger', function() {
     });
 
     it('should allow setting default tags', function() {
-        var l = new BufferedMetricsLogger({
+        const l = new BufferedMetricsLogger({
             reporter: new reporters.NullReporter(),
             defaultTags: ['one', 'two']
         });
@@ -120,7 +120,7 @@ describe('BufferedMetricsLogger', function() {
     });
 
     it('should allow setting apiHost/site', function() {
-        var l = new BufferedMetricsLogger({
+        const l = new BufferedMetricsLogger({
             apiKey: 'abc123',
             apiHost: 'datadoghq.eu'
         });
@@ -128,7 +128,7 @@ describe('BufferedMetricsLogger', function() {
     });
 
     it('should allow setting apiHost/site with "app.*" URLs', function() {
-        var l = new BufferedMetricsLogger({
+        const l = new BufferedMetricsLogger({
             apiKey: 'abc123',
             apiHost: 'app.datadoghq.eu'
         });

--- a/test/metrics_tests.js
+++ b/test/metrics_tests.js
@@ -2,30 +2,30 @@
 
 'use strict';
 
-var chai = require('chai');
+const chai = require('chai');
 chai.use(require('chai-string'));
 
-var should = chai.should();
+const should = chai.should();
 
-var metrics = require('../lib/metrics');
+const metrics = require('../lib/metrics');
 
 describe('Metric', function() {
     it('should set its initial state correctly', function() {
-        var m = new metrics.Metric('the.key', ['tag1'], 'myhost');
+        const m = new metrics.Metric('the.key', ['tag1'], 'myhost');
         m.key.should.equal('the.key');
         m.tags.should.deep.equal(['tag1']);
         m.host.should.equal('myhost');
     });
 
     it('should update the timestamp with Date.now when a data point is added', function() {
-        var m = new metrics.Metric();
-        var now = Date.now();
+        const m = new metrics.Metric();
+        const now = Date.now();
         m.updateTimestamp();
-        var diff = (m.timestamp * 1000) - now;
+        const diff = (m.timestamp * 1000) - now;
         Math.abs(diff).should.lessThan(1000); // within one second
     });
     it('should update the timestamp when a data point is added with a timestamp in ms', function() {
-        var m = new metrics.Metric();
+        const m = new metrics.Metric();
         m.updateTimestamp(123000);
         m.timestamp.should.equal(123);
     });
@@ -33,14 +33,14 @@ describe('Metric', function() {
 
 describe('Gauge', function() {
     it('should extend Metric', function() {
-        var g = new metrics.Gauge();
+        const g = new metrics.Gauge();
         g.updateTimestamp.should.be.a('function');
     });
 
     it('should flush correctly', function() {
-        var g = new metrics.Gauge('the.key', ['mytag'], 'myhost');
+        const g = new metrics.Gauge('the.key', ['mytag'], 'myhost');
         g.addPoint(1);
-        var f = g.flush();
+        const f = g.flush();
         f.should.have.length(1);
         f[0].should.have.deep.property('metric', 'the.key');
         f[0].should.have.deep.property('tags[0]', 'mytag');
@@ -51,9 +51,9 @@ describe('Gauge', function() {
     });
 
     it('should flush correctly when given timestamp', function() {
-        var g = new metrics.Gauge('the.key', ['mytag'], 'myhost');
+        const g = new metrics.Gauge('the.key', ['mytag'], 'myhost');
         g.addPoint(1, 123000);
-        var f = g.flush();
+        const f = g.flush();
         f.should.have.length(1);
         f[0].should.have.deep.property('metric', 'the.key');
         f[0].should.have.deep.property('tags[0]', 'mytag');
@@ -66,14 +66,14 @@ describe('Gauge', function() {
 
 describe('Counter', function() {
     it('should extend Metric', function() {
-        var g = new metrics.Counter();
+        const g = new metrics.Counter();
         g.updateTimestamp.should.be.a('function');
     });
 
     it('should flush correctly', function() {
-        var g = new metrics.Counter('the.key', ['mytag'], 'myhost');
+        const g = new metrics.Counter('the.key', ['mytag'], 'myhost');
         g.addPoint(1);
-        var f = g.flush();
+        const f = g.flush();
         f.should.have.length(1);
         f[0].should.have.deep.property('metric', 'the.key');
         f[0].should.have.deep.property('tags[0]', 'mytag');
@@ -84,9 +84,9 @@ describe('Counter', function() {
     });
 
     it('should flush correctly when given a timestamp', function() {
-        var g = new metrics.Counter('the.key', ['mytag'], 'myhost');
+        const g = new metrics.Counter('the.key', ['mytag'], 'myhost');
         g.addPoint(1, 123000);
-        var f = g.flush();
+        const f = g.flush();
         f.should.have.length(1);
         f[0].should.have.deep.property('metric', 'the.key');
         f[0].should.have.deep.property('tags[0]', 'mytag');
@@ -99,13 +99,13 @@ describe('Counter', function() {
 
 describe('Histogram', function() {
     it('should extend Metric', function() {
-        var h = new metrics.Histogram();
+        const h = new metrics.Histogram();
         h.updateTimestamp.should.be.a('function');
     });
 
     it('should report the min and max of all values', function() {
-        var h = new metrics.Histogram('hist');
-        var f = h.flush();
+        const h = new metrics.Histogram('hist');
+        let f = h.flush();
 
         f.should.have.deep.property('[0].metric', 'hist.min');
         f.should.have.deep.property('[0].points[0][1]', Infinity);
@@ -122,8 +122,8 @@ describe('Histogram', function() {
     });
 
     it('should report a sum of all values', function() {
-        var h = new metrics.Histogram('hist');
-        var f = h.flush();
+        const h = new metrics.Histogram('hist');
+        let f = h.flush();
 
         f.should.have.deep.property('[2].metric', 'hist.sum');
         f.should.have.deep.property('[2].points[0][1]', 0);
@@ -137,8 +137,8 @@ describe('Histogram', function() {
     });
 
     it('should report the number of samples (count)', function() {
-        var h = new metrics.Histogram('hist');
-        var f = h.flush();
+        const h = new metrics.Histogram('hist');
+        let f = h.flush();
 
         f.should.have.deep.property('[3].metric', 'hist.count');
         f.should.have.deep.property('[3].points[0][1]', 0);
@@ -152,8 +152,8 @@ describe('Histogram', function() {
     });
 
     it('should report the average', function() {
-        var h = new metrics.Histogram('hist');
-        var f = h.flush();
+        const h = new metrics.Histogram('hist');
+        let f = h.flush();
 
         f.should.have.deep.property('[4].metric', 'hist.avg');
         f.should.have.deep.property('[4].points[0][1]', 0);
@@ -167,8 +167,8 @@ describe('Histogram', function() {
     });
 
     it('should report the median', function() {
-        var h = new metrics.Histogram('hist');
-        var f = h.flush();
+        const h = new metrics.Histogram('hist');
+        let f = h.flush();
 
         f.should.have.deep.property('[5].metric', 'hist.median');
         f.should.have.deep.property('[5].points[0][1]', 0);
@@ -189,9 +189,9 @@ describe('Histogram', function() {
     });
 
     it('should report the correct percentiles', function() {
-        var h = new metrics.Histogram('hist');
+        const h = new metrics.Histogram('hist');
         h.addPoint(1);
-        var f = h.flush();
+        let f = h.flush();
 
         f.should.have.deep.property('[6].metric', 'hist.75percentile');
         f.should.have.deep.property('[6].points[0][1]', 1);
@@ -204,7 +204,7 @@ describe('Histogram', function() {
 
         // Create 100 samples from [1..100] so we can
         // verify the calculated percentiles.
-        for (var i = 2; i <= 100; i++) {
+        for (let i = 2; i <= 100; i++) {
             h.addPoint(i);
         }
         f = h.flush();
@@ -224,7 +224,7 @@ describe('Histogram', function() {
         const percentiles = [0.85];
         const h = new metrics.Histogram('hist', [], 'myhost', { aggregates, percentiles });
         h.addPoint(1);
-        var f = h.flush();
+        let f = h.flush();
 
         f.should.have.deep.property('[0].metric', 'hist.avg');
         f.should.have.deep.property('[0].points[0][1]', 1);
@@ -234,7 +234,7 @@ describe('Histogram', function() {
 
         // Create 100 samples from [1..100] so we can
         // verify the calculated percentiles.
-        for (var i = 2; i <= 100; i++) {
+        for (let i = 2; i <= 100; i++) {
             h.addPoint(i);
         }
         f = h.flush();
@@ -247,14 +247,14 @@ describe('Histogram', function() {
 
 describe('Distribution', function() {
     it('should extend Metric', function() {
-        var g = new metrics.Distribution();
+        const g = new metrics.Distribution();
         g.updateTimestamp.should.be.a('function');
     });
 
     it('should flush correctly', function() {
-        var g = new metrics.Distribution('the.key', ['mytag'], 'myhost');
+        const g = new metrics.Distribution('the.key', ['mytag'], 'myhost');
         g.addPoint(1);
-        var f = g.flush();
+        const f = g.flush();
         f.should.have.length(1);
         f[0].should.have.deep.property('metric', 'the.key');
         f[0].should.have.deep.property('tags[0]', 'mytag');
@@ -266,9 +266,9 @@ describe('Distribution', function() {
     });
 
     it('should flush correctly when given timestamp', function() {
-        var g = new metrics.Distribution('the.key', ['mytag'], 'myhost');
+        const g = new metrics.Distribution('the.key', ['mytag'], 'myhost');
         g.addPoint(1, 123000);
-        var f = g.flush();
+        const f = g.flush();
         f.should.have.length(1);
         f[0].should.have.deep.property('metric', 'the.key');
         f[0].should.have.deep.property('tags[0]', 'mytag');
@@ -280,12 +280,12 @@ describe('Distribution', function() {
     });
 
     it('should format multiple points from different times', function () {
-        var g = new metrics.Distribution('the.key', ['mytag'], 'myhost');
+        const g = new metrics.Distribution('the.key', ['mytag'], 'myhost');
         g.addPoint(1, 123000);
         g.addPoint(2, 125000);
         g.addPoint(3, 121000);
 
-        var f = g.flush();
+        const f = g.flush();
         f.should.have.length(1);
         f[0].points.should.eql([
             [123, [1]],
@@ -295,12 +295,12 @@ describe('Distribution', function() {
     });
 
     it('should format multiple points from the same time', function () {
-        var g = new metrics.Distribution('the.key', ['mytag'], 'myhost');
+        const g = new metrics.Distribution('the.key', ['mytag'], 'myhost');
         g.addPoint(1, 123000);
         g.addPoint(2, 125000);
         g.addPoint(3, 125000);
 
-        var f = g.flush();
+        const f = g.flush();
         f.should.have.length(1);
         f[0].points.should.eql([
             [123, [1]],

--- a/test/module_tests.js
+++ b/test/module_tests.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var chai = require('chai');
-var should = chai.should();
+const chai = require('chai');
+const should = chai.should();
 
-var metrics = null;
-var reporters = require('../lib/reporters.js');
+let metrics = null;
+const reporters = require('../lib/reporters.js');
 
 // Force-reload the module before every test so we
 // can realistically test all the scenarios.
@@ -18,7 +18,7 @@ beforeEach(function() {
 describe('datadog-metrics', function() {
     it('should let me create a metrics logger instance', function() {
         metrics.BufferedMetricsLogger.should.be.a('function');
-        var logger = new metrics.BufferedMetricsLogger({
+        const logger = new metrics.BufferedMetricsLogger({
             reporter: new reporters.NullReporter()
         });
         logger.gauge('test.gauge', 23);
@@ -81,5 +81,5 @@ describe('datadog-metrics', function() {
     it('should publicly export built-in reporters', function() {
         metrics.reporters.should.have.property('DataDogReporter', reporters.DataDogReporter);
         metrics.reporters.should.have.property('NullReporter', reporters.NullReporter);
-    })
+    });
 });


### PR DESCRIPTION
This updates the linting tools we currently have (JSHint and JSCS) to their latest versions, updates their configurations to the latest versions, and turns them on in CI. This at least gets us to something that works so we have more checking for pull requests, but a future PR should remove JSCS, since it is no longer maintained and comes with a number of security vulnerabilities.

Solves the most immediate problems in #85, but doesn’t fully close the issue.

**This needs one more commit to actually resolve lint errors.** I haven’t included it yet so we can verify CI fails.