### PR TITLE
Update test dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jscs": "3.0.7",
     "jshint": "^2.13.5",
     "jshint-stylish-ex": "0.2.0",
-    "mocha": "2.4.5"
+    "mocha": "9.2.2"
   },
   "dependencies": {
     "@datadog/datadog-api-client": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "author": "Daniel Bader <mail@dbader.org> (http://dbader.org/)",
   "license": "MIT",
   "devDependencies": {
-    "chai": "3.5.0",
-    "chai-string": "1.1.6",
+    "chai": "4.3.6",
+    "chai-string": "1.5.0",
     "jscs": "3.0.7",
     "jshint": "^2.13.5",
     "jshint-stylish-ex": "0.2.0",

--- a/test/aggregators_tests.js
+++ b/test/aggregators_tests.js
@@ -13,34 +13,34 @@ const metrics = require('../lib/metrics');
 describe('Aggregator', function() {
     it('should flush correctly when empty', function() {
         const agg = new aggregators.Aggregator();
-        agg.flush().should.have.length(0);
+        agg.flush().should.have.lengthOf(0);
     });
 
     it('should flush a single metric correctly', function() {
         const agg = new aggregators.Aggregator();
         agg.addPoint(metrics.Gauge, 'mykey', 23, ['mytag'], 'myhost');
-        agg.flush().should.have.length(1);
+        agg.flush().should.have.lengthOf(1);
     });
 
     it('should flush multiple metrics correctly', function() {
         const agg = new aggregators.Aggregator();
         agg.addPoint(metrics.Gauge, 'mykey', 23, ['mytag'], 'myhost');
         agg.addPoint(metrics.Gauge, 'mykey2', 42, ['mytag'], 'myhost');
-        agg.flush().should.have.length(2);
+        agg.flush().should.have.lengthOf(2);
     });
 
     it('should flush multiple metrics correctly even if only the tag differs', function() {
         const agg = new aggregators.Aggregator();
         agg.addPoint(metrics.Gauge, 'mykey', 23, ['mytag1'], 'myhost');
         agg.addPoint(metrics.Gauge, 'mykey', 23, ['mytag2'], 'myhost');
-        agg.flush().should.have.length(2);
+        agg.flush().should.have.lengthOf(2);
     });
 
     it('should clear the buffer after flushing', function() {
         const agg = new aggregators.Aggregator();
         agg.addPoint(metrics.Gauge, 'mykey', 23, ['mytag'], 'myhost');
-        agg.flush().should.have.length(1);
-        agg.flush().should.have.length(0);
+        agg.flush().should.have.lengthOf(1);
+        agg.flush().should.have.lengthOf(0);
     });
 
     it('should update an existing metric correctly', function() {
@@ -48,8 +48,9 @@ describe('Aggregator', function() {
         agg.addPoint(metrics.Counter, 'test.mykey', 2, ['mytag'], 'myhost');
         agg.addPoint(metrics.Counter, 'test.mykey', 3, ['mytag'], 'myhost');
         const f = agg.flush();
-        f.should.have.length(1);
-        f[0].should.have.deep.property('points[0][1]', 5);
+        f.should.have.lengthOf(1);
+        f[0].should.have.nested.property('points[0][1]', 5);
+        f[0].points.should.have.lengthOf(1);
     });
 
     it('should aggregate by key + tag', function() {
@@ -57,9 +58,9 @@ describe('Aggregator', function() {
         agg.addPoint(metrics.Counter, 'test.mykey', 2, ['mytag1'], 'myhost');
         agg.addPoint(metrics.Counter, 'test.mykey', 3, ['mytag2'], 'myhost');
         const f = agg.flush();
-        f.should.have.length(2);
-        f[0].should.have.deep.property('points[0][1]', 2);
-        f[1].should.have.deep.property('points[0][1]', 3);
+        f.should.have.lengthOf(2);
+        f[0].should.have.nested.property('points[0][1]', 2);
+        f[1].should.have.nested.property('points[0][1]', 3);
     });
 
     it('should treat all empty tags definitions the same', function() {
@@ -68,8 +69,8 @@ describe('Aggregator', function() {
         agg.addPoint(metrics.Gauge, 'noTagsKey', 2, undefined, 'myhost');
         agg.addPoint(metrics.Gauge, 'noTagsKey', 3, [], 'myhost');
         const f = agg.flush();
-        f.should.have.length(1);
-        f[0].should.have.deep.property('points[0][1]', 3);
+        f.should.have.lengthOf(1);
+        f[0].should.have.nested.property('points[0][1]', 3);
     });
 
     it('should normalize the tag order', function() {
@@ -77,8 +78,8 @@ describe('Aggregator', function() {
         agg.addPoint(metrics.Gauge, 'mykey', 1, ['t1', 't2', 't3'], 'myhost');
         agg.addPoint(metrics.Gauge, 'mykey', 2, ['t3', 't2', 't1'], 'myhost');
         const f = agg.flush();
-        f.should.have.length(1);
-        f[0].should.have.deep.property('points[0][1]', 2);
+        f.should.have.lengthOf(1);
+        f[0].should.have.nested.property('points[0][1]', 2);
     });
 
     it('should report default tags', function() {
@@ -87,7 +88,7 @@ describe('Aggregator', function() {
         agg.addPoint(metrics.Counter, 'test.mykey', 2, ['mytag1'], 'myhost');
         agg.addPoint(metrics.Counter, 'test.mykey', 3, ['mytag2'], 'myhost');
         const f = agg.flush();
-        f.should.have.length(2);
+        f.should.have.lengthOf(2);
         f[0].tags.should.eql(['one', 'two', 'mytag1']);
         f[1].tags.should.eql(['one', 'two', 'mytag2']);
     });

--- a/test/metrics_tests.js
+++ b/test/metrics_tests.js
@@ -41,26 +41,24 @@ describe('Gauge', function() {
         const g = new metrics.Gauge('the.key', ['mytag'], 'myhost');
         g.addPoint(1);
         const f = g.flush();
-        f.should.have.length(1);
-        f[0].should.have.deep.property('metric', 'the.key');
-        f[0].should.have.deep.property('tags[0]', 'mytag');
-        f[0].should.have.deep.property('host', 'myhost');
-        f[0].should.have.deep.property('type', 'gauge');
-        f[0].should.have.deep.property('points[0][0]', g.timestamp);
-        f[0].should.have.deep.property('points[0][1]', 1);
+        f.should.have.lengthOf(1);
+        f[0].should.have.property('metric', 'the.key');
+        f[0].should.have.deep.property('tags', ['mytag']);
+        f[0].should.have.property('host', 'myhost');
+        f[0].should.have.property('type', 'gauge');
+        f[0].should.have.deep.property('points', [[ g.timestamp, 1 ]]);
     });
 
     it('should flush correctly when given timestamp', function() {
         const g = new metrics.Gauge('the.key', ['mytag'], 'myhost');
         g.addPoint(1, 123000);
         const f = g.flush();
-        f.should.have.length(1);
-        f[0].should.have.deep.property('metric', 'the.key');
-        f[0].should.have.deep.property('tags[0]', 'mytag');
-        f[0].should.have.deep.property('host', 'myhost');
-        f[0].should.have.deep.property('type', 'gauge');
-        f[0].should.have.deep.property('points[0][0]', 123);
-        f[0].should.have.deep.property('points[0][1]', 1);
+        f.should.have.lengthOf(1);
+        f[0].should.have.property('metric', 'the.key');
+        f[0].should.have.deep.property('tags', ['mytag']);
+        f[0].should.have.property('host', 'myhost');
+        f[0].should.have.property('type', 'gauge');
+        f[0].should.have.deep.property('points', [[ 123, 1 ]]);
     });
 });
 
@@ -74,26 +72,24 @@ describe('Counter', function() {
         const g = new metrics.Counter('the.key', ['mytag'], 'myhost');
         g.addPoint(1);
         const f = g.flush();
-        f.should.have.length(1);
-        f[0].should.have.deep.property('metric', 'the.key');
-        f[0].should.have.deep.property('tags[0]', 'mytag');
-        f[0].should.have.deep.property('host', 'myhost');
-        f[0].should.have.deep.property('type', 'count');
-        f[0].should.have.deep.property('points[0][0]', g.timestamp);
-        f[0].should.have.deep.property('points[0][1]', 1);
+        f.should.have.lengthOf(1);
+        f[0].should.have.property('metric', 'the.key');
+        f[0].should.have.deep.property('tags', ['mytag']);
+        f[0].should.have.property('host', 'myhost');
+        f[0].should.have.property('type', 'count');
+        f[0].should.have.deep.property('points', [[ g.timestamp, 1 ]]);
     });
 
     it('should flush correctly when given a timestamp', function() {
         const g = new metrics.Counter('the.key', ['mytag'], 'myhost');
         g.addPoint(1, 123000);
         const f = g.flush();
-        f.should.have.length(1);
-        f[0].should.have.deep.property('metric', 'the.key');
-        f[0].should.have.deep.property('tags[0]', 'mytag');
-        f[0].should.have.deep.property('host', 'myhost');
-        f[0].should.have.deep.property('type', 'count');
-        f[0].should.have.deep.property('points[0][0]', 123);
-        f[0].should.have.deep.property('points[0][1]', 1);
+        f.should.have.lengthOf(1);
+        f[0].should.have.property('metric', 'the.key');
+        f[0].should.have.deep.property('tags', ['mytag']);
+        f[0].should.have.property('host', 'myhost');
+        f[0].should.have.property('type', 'count');
+        f[0].should.have.deep.property('points', [[ 123, 1 ]]);
     });
 });
 
@@ -107,85 +103,85 @@ describe('Histogram', function() {
         const h = new metrics.Histogram('hist');
         let f = h.flush();
 
-        f.should.have.deep.property('[0].metric', 'hist.min');
-        f.should.have.deep.property('[0].points[0][1]', Infinity);
-        f.should.have.deep.property('[1].metric', 'hist.max');
-        f.should.have.deep.property('[1].points[0][1]', -Infinity);
+        f.should.have.nested.property('[0].metric', 'hist.min');
+        f.should.have.nested.deep.property('[0].points', [[ h.timestamp, Infinity ]]);
+        f.should.have.nested.property('[1].metric', 'hist.max');
+        f.should.have.nested.deep.property('[1].points', [[ h.timestamp, -Infinity ]]);
 
         h.addPoint(23);
 
         f = h.flush();
-        f.should.have.deep.property('[0].metric', 'hist.min');
-        f.should.have.deep.property('[0].points[0][1]', 23);
-        f.should.have.deep.property('[1].metric', 'hist.max');
-        f.should.have.deep.property('[1].points[0][1]', 23);
+        f.should.have.nested.property('[0].metric', 'hist.min');
+        f.should.have.nested.deep.property('[0].points', [[ h.timestamp, 23 ]]);
+        f.should.have.nested.property('[1].metric', 'hist.max');
+        f.should.have.nested.deep.property('[0].points', [[ h.timestamp, 23 ]]);
     });
 
     it('should report a sum of all values', function() {
         const h = new metrics.Histogram('hist');
         let f = h.flush();
 
-        f.should.have.deep.property('[2].metric', 'hist.sum');
-        f.should.have.deep.property('[2].points[0][1]', 0);
+        f.should.have.nested.property('[2].metric', 'hist.sum');
+        f.should.have.nested.deep.property('[2].points', [[ h.timestamp, 0 ]]);
 
         h.addPoint(2);
         h.addPoint(3);
 
         f = h.flush();
-        f.should.have.deep.property('[2].metric', 'hist.sum');
-        f.should.have.deep.property('[2].points[0][1]', 5);
+        f.should.have.nested.property('[2].metric', 'hist.sum');
+        f.should.have.nested.deep.property('[2].points', [[ h.timestamp, 5 ]]);
     });
 
     it('should report the number of samples (count)', function() {
         const h = new metrics.Histogram('hist');
         let f = h.flush();
 
-        f.should.have.deep.property('[3].metric', 'hist.count');
-        f.should.have.deep.property('[3].points[0][1]', 0);
+        f.should.have.nested.property('[3].metric', 'hist.count');
+        f.should.have.nested.deep.property('[3].points', [[ h.timestamp, 0 ]]);
 
         h.addPoint(2);
         h.addPoint(3);
 
         f = h.flush();
-        f.should.have.deep.property('[3].metric', 'hist.count');
-        f.should.have.deep.property('[3].points[0][1]', 2);
+        f.should.have.nested.property('[3].metric', 'hist.count');
+        f.should.have.nested.deep.property('[3].points', [[ h.timestamp, 2 ]]);
     });
 
     it('should report the average', function() {
         const h = new metrics.Histogram('hist');
         let f = h.flush();
 
-        f.should.have.deep.property('[4].metric', 'hist.avg');
-        f.should.have.deep.property('[4].points[0][1]', 0);
+        f.should.have.nested.property('[4].metric', 'hist.avg');
+        f.should.have.nested.deep.property('[4].points', [[ h.timestamp, 0 ]]);
 
         h.addPoint(2);
         h.addPoint(3);
 
         f = h.flush();
-        f.should.have.deep.property('[4].metric', 'hist.avg');
-        f.should.have.deep.property('[4].points[0][1]', 2.5);
+        f.should.have.nested.property('[4].metric', 'hist.avg');
+        f.should.have.nested.deep.property('[4].points', [[ h.timestamp, 2.5 ]]);
     });
 
     it('should report the median', function() {
         const h = new metrics.Histogram('hist');
         let f = h.flush();
 
-        f.should.have.deep.property('[5].metric', 'hist.median');
-        f.should.have.deep.property('[5].points[0][1]', 0);
+        f.should.have.nested.property('[5].metric', 'hist.median');
+        f.should.have.nested.deep.property('[5].points', [[ h.timestamp, 0 ]]);
 
         h.addPoint(2);
         h.addPoint(3);
         h.addPoint(10);
 
         f = h.flush();
-        f.should.have.deep.property('[5].metric', 'hist.median');
-        f.should.have.deep.property('[5].points[0][1]', 3);
+        f.should.have.nested.property('[5].metric', 'hist.median');
+        f.should.have.nested.deep.property('[5].points', [[ h.timestamp, 3 ]]);
 
         h.addPoint(4);
 
         f = h.flush();
-        f.should.have.deep.property('[5].metric', 'hist.median');
-        f.should.have.deep.property('[5].points[0][1]', 3.5);
+        f.should.have.nested.property('[5].metric', 'hist.median');
+        f.should.have.nested.deep.property('[5].points', [[ h.timestamp, 3.5 ]]);
     });
 
     it('should report the correct percentiles', function() {
@@ -193,14 +189,14 @@ describe('Histogram', function() {
         h.addPoint(1);
         let f = h.flush();
 
-        f.should.have.deep.property('[6].metric', 'hist.75percentile');
-        f.should.have.deep.property('[6].points[0][1]', 1);
-        f.should.have.deep.property('[7].metric', 'hist.85percentile');
-        f.should.have.deep.property('[7].points[0][1]', 1);
-        f.should.have.deep.property('[8].metric', 'hist.95percentile');
-        f.should.have.deep.property('[8].points[0][1]', 1);
-        f.should.have.deep.property('[9].metric', 'hist.99percentile');
-        f.should.have.deep.property('[9].points[0][1]', 1);
+        f.should.have.nested.property('[6].metric', 'hist.75percentile');
+        f.should.have.nested.deep.property('[6].points', [[ h.timestamp, 1 ]]);
+        f.should.have.nested.property('[7].metric', 'hist.85percentile');
+        f.should.have.nested.deep.property('[7].points', [[ h.timestamp, 1 ]]);
+        f.should.have.nested.property('[8].metric', 'hist.95percentile');
+        f.should.have.nested.deep.property('[8].points', [[ h.timestamp, 1 ]]);
+        f.should.have.nested.property('[9].metric', 'hist.99percentile');
+        f.should.have.nested.deep.property('[9].points', [[ h.timestamp, 1 ]]);
 
         // Create 100 samples from [1..100] so we can
         // verify the calculated percentiles.
@@ -209,14 +205,14 @@ describe('Histogram', function() {
         }
         f = h.flush();
 
-        f.should.have.deep.property('[6].metric', 'hist.75percentile');
-        f.should.have.deep.property('[6].points[0][1]', 75);
-        f.should.have.deep.property('[7].metric', 'hist.85percentile');
-        f.should.have.deep.property('[7].points[0][1]', 85);
-        f.should.have.deep.property('[8].metric', 'hist.95percentile');
-        f.should.have.deep.property('[8].points[0][1]', 95);
-        f.should.have.deep.property('[9].metric', 'hist.99percentile');
-        f.should.have.deep.property('[9].points[0][1]', 99);
+        f.should.have.nested.property('[6].metric', 'hist.75percentile');
+        f.should.have.nested.deep.property('[6].points', [[ h.timestamp, 75 ]]);
+        f.should.have.nested.property('[7].metric', 'hist.85percentile');
+        f.should.have.nested.deep.property('[7].points', [[ h.timestamp, 85 ]]);
+        f.should.have.nested.property('[8].metric', 'hist.95percentile');
+        f.should.have.nested.deep.property('[8].points', [[ h.timestamp, 95 ]]);
+        f.should.have.nested.property('[9].metric', 'hist.99percentile');
+        f.should.have.nested.deep.property('[9].points', [[ h.timestamp, 99 ]]);
     });
 
     it('should use custom percentiles and aggregates', function() {
@@ -226,11 +222,11 @@ describe('Histogram', function() {
         h.addPoint(1);
         let f = h.flush();
 
-        f.should.have.deep.property('[0].metric', 'hist.avg');
-        f.should.have.deep.property('[0].points[0][1]', 1);
+        f.should.have.nested.property('[0].metric', 'hist.avg');
+        f.should.have.nested.deep.property('[0].points', [[ h.timestamp, 1 ]]);
 
-        f.should.have.deep.property('[1].metric', 'hist.85percentile');
-        f.should.have.deep.property('[1].points[0][1]', 1);
+        f.should.have.nested.property('[1].metric', 'hist.85percentile');
+        f.should.have.nested.deep.property('[1].points', [[ h.timestamp, 1 ]]);
 
         // Create 100 samples from [1..100] so we can
         // verify the calculated percentiles.
@@ -239,9 +235,8 @@ describe('Histogram', function() {
         }
         f = h.flush();
 
-        f.should.have.deep.property('[1].metric', 'hist.85percentile');
-        f.should.have.deep.property('[1].points[0][1]', 85);
-
+        f.should.have.nested.property('[1].metric', 'hist.85percentile');
+        f.should.have.nested.deep.property('[1].points', [[ h.timestamp, 85 ]]);
     });
 });
 
@@ -255,28 +250,24 @@ describe('Distribution', function() {
         const g = new metrics.Distribution('the.key', ['mytag'], 'myhost');
         g.addPoint(1);
         const f = g.flush();
-        f.should.have.length(1);
-        f[0].should.have.deep.property('metric', 'the.key');
-        f[0].should.have.deep.property('tags[0]', 'mytag');
-        f[0].should.have.deep.property('host', 'myhost');
-        f[0].should.have.deep.property('type', 'distribution');
-        f[0].should.have.deep.property('points[0][0]', g.timestamp);
-        f[0].should.have.deep.property('points[0][1][0]', 1);
-        f[0].points[0][1].should.have.length(1);
+        f.should.have.lengthOf(1);
+        f[0].should.have.property('metric', 'the.key');
+        f[0].should.have.deep.property('tags', ['mytag']);
+        f[0].should.have.property('host', 'myhost');
+        f[0].should.have.property('type', 'distribution');
+        f[0].should.have.deep.property('points', [[ g.timestamp, [1] ]]);
     });
 
     it('should flush correctly when given timestamp', function() {
         const g = new metrics.Distribution('the.key', ['mytag'], 'myhost');
         g.addPoint(1, 123000);
         const f = g.flush();
-        f.should.have.length(1);
-        f[0].should.have.deep.property('metric', 'the.key');
-        f[0].should.have.deep.property('tags[0]', 'mytag');
-        f[0].should.have.deep.property('host', 'myhost');
-        f[0].should.have.deep.property('type', 'distribution');
-        f[0].should.have.deep.property('points[0][0]', 123);
-        f[0].should.have.deep.property('points[0][1][0]', 1);
-        f[0].points[0][1].should.have.length(1);
+        f.should.have.lengthOf(1);
+        f[0].should.have.property('metric', 'the.key');
+        f[0].should.have.deep.property('tags', ['mytag']);
+        f[0].should.have.property('host', 'myhost');
+        f[0].should.have.property('type', 'distribution');
+        f[0].should.have.deep.property('points', [[ 123, [1] ]]);
     });
 
     it('should format multiple points from different times', function () {
@@ -286,7 +277,7 @@ describe('Distribution', function() {
         g.addPoint(3, 121000);
 
         const f = g.flush();
-        f.should.have.length(1);
+        f.should.have.lengthOf(1);
         f[0].points.should.eql([
             [123, [1]],
             [125, [2]],
@@ -301,7 +292,7 @@ describe('Distribution', function() {
         g.addPoint(3, 125000);
 
         const f = g.flush();
-        f.should.have.length(1);
+        f.should.have.lengthOf(1);
         f[0].points.should.eql([
             [123, [1]],
             [125, [2, 3]]

--- a/test/module_tests.js
+++ b/test/module_tests.js
@@ -30,10 +30,10 @@ describe('datadog-metrics', function() {
             flushIntervalSeconds: 0,
             reporter: {
                 report (series, onSuccess, onError) {
-                    series.should.have.length(12); // 3 + 9 for the histogram.
-                    series[0].should.have.deep.property('points[0][1]', 23);
-                    series[0].should.have.deep.property('metric', 'test.gauge');
-                    series[0].tags.should.have.length(0);
+                    series.should.have.lengthOf(12); // 3 + 9 for the histogram.
+                    series[0].should.have.nested.property('points[0][1]', 23);
+                    series[0].should.have.property('metric', 'test.gauge');
+                    series[0].tags.should.have.lengthOf(0);
                     onSuccess && onSuccess();
                     done();
                 }
@@ -52,13 +52,13 @@ describe('datadog-metrics', function() {
             flushIntervalSeconds: 0,
             reporter: {
                 report (series, onSuccess, onError) {
-                    series.should.have.length(2);
-                    series[0].should.have.deep.property('points[0][1]', 1);
-                    series[0].should.have.deep.property('metric', 'test.gauge');
-                    series[0].should.have.deep.property('tags[0]', 'tag1');
-                    series[1].should.have.deep.property('points[0][1]', 2);
-                    series[1].should.have.deep.property('metric', 'test.gauge');
-                    series[1].should.have.deep.property('tags[0]', 'tag2');
+                    series.should.have.lengthOf(2);
+                    series[0].should.have.nested.property('points[0][1]', 1);
+                    series[0].should.have.property('metric', 'test.gauge');
+                    series[0].should.have.deep.property('tags', ['tag1']);
+                    series[1].should.have.nested.property('points[0][1]', 2);
+                    series[1].should.have.property('metric', 'test.gauge');
+                    series[1].should.have.deep.property('tags', ['tag2']);
                     onSuccess && onSuccess();
                     done();
                 }


### PR DESCRIPTION
This updates Mocha and Chai (and plugins) to their latest compatible versions and fixes #87.

Mocha v10 (the latest) drops support for Node.js v12, so we can't update to it. Instead, we can update to the latest v9.x release, which at least fixes a number of security vulnerabilities. Our usage of Mocha isn't too complex so happily none of our tests need to change for this.

On the other hand, there are some big breaking changes in Chai v4, so this involves a bunch of changes to the tests. The most significant thing is that `deep` now always and only means to do a deep equality check on the value being compared to, while a new `nested` property always means that the provided *keys* might be keys or might be paths. In v3.x, `deep` was used for both in different circumstances, which led to some fuzziness about what a given assertion is doing.

This depends on and is set up to be merged into #92. We can merge it into that and then merge that, or we can merge that first and rebase this.