### PR TITLE
Declare supported version of Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The downside of using the HTTP API is that it can negatively affect your app's p
 
 ## Installation
 
+Datadog-metrics is compatible with Node.js v12 and later. You can install it with NPM:
+
 ```sh
 npm install datadog-metrics --save
 ```

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   "dependencies": {
     "@datadog/datadog-api-client": "^1.3.0",
     "debug": "^4.1.0"
+  },
+  "engines": {
+    "node": ">=12.0.0"
   }
 }


### PR DESCRIPTION
This adds information about the supported versions of Node.js in the README and in the `engines` field of `package.json` (so NPM can show warnings).