### PR TITLE
Keep separate Datadog clients for each reporter

### DIFF
--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -1,7 +1,6 @@
 'use strict';
 const debug = require('debug')('metrics');
 const datadogApiClient = require('@datadog/datadog-api-client');
-let metricsApi;
 
 //
 // NullReporter
@@ -21,6 +20,8 @@ NullReporter.prototype.report = function(series, onSuccess) {
 //
 // DataDogReporter
 //
+
+const datadogClients = new WeakMap();
 
 function DataDogReporter(apiKey, appKey, apiHost) {
     apiKey = apiKey || process.env.DATADOG_API_KEY;
@@ -46,7 +47,7 @@ function DataDogReporter(apiKey, appKey, apiHost) {
             site: this.apiHost
         });
     }
-    metricsApi = new datadogApiClient.v1.MetricsApi(configuration);
+    datadogClients.set(this, new datadogApiClient.v1.MetricsApi(configuration));
 }
 
 DataDogReporter.prototype.report = function(series, onSuccess, onError) {
@@ -66,6 +67,8 @@ DataDogReporter.prototype.report = function(series, onSuccess, onError) {
             metrics.push(metric);
         }
     }
+
+    const metricsApi = datadogClients.get(this);
 
     let submissions = [];
     if (metrics.length) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "jscs": "3.0.7",
     "jshint": "^2.13.5",
     "jshint-stylish-ex": "0.2.0",
-    "mocha": "9.2.2"
+    "mocha": "9.2.2",
+    "nock": "^13.2.9"
   },
   "dependencies": {
     "@datadog/datadog-api-client": "^1.3.0",

--- a/test/loggers_tests.js
+++ b/test/loggers_tests.js
@@ -154,7 +154,7 @@ describe('BufferedMetricsLogger', function() {
 
         logger.flush(
             () => done(),
-            (error) => done(error || new Error("Error handler called with no error object."))
+            (error) => done(error || new Error('Error handler called with no error object.'))
         );
     });
 
@@ -167,7 +167,7 @@ describe('BufferedMetricsLogger', function() {
         logger.gauge('test.gauge', 23);
 
         logger.flush(
-            () => done(new Error("The success handler was called!")),
+            () => done(new Error('The success handler was called!')),
             (error) => done()
         );
     });
@@ -201,7 +201,7 @@ describe('BufferedMetricsLogger', function() {
                     () => {
                         try {
                             receivedKeys.should.deep.equal(apiKeys);
-                        } catch(error) {
+                        } catch (error) {
                             return done(error);
                         }
                         done();


### PR DESCRIPTION
This fixes #82 by using a WeakMap to keep a separate Datadog client for each instance of `DataDogReporter`. Previously, there was a single shared client across all reporter instances, so creating a second reporter (usually by creating a second logger) would overwrite the credentials of the first reporter.

This also adds [Nock](https://www.npmjs.com/package/nock) for intercepting HTTP requests during tests (the other good option for this in JS is [Polly](https://netflix.github.io/pollyjs/), but I find it a bit more complex to set up; both have good VCR-style replay tools, although I didn’t use that here). While I was at it, I also added success/error handler tests for `flush()`.