### PR TITLE
Add lint script for bad case on "Datadog"

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ max_line_length = 110
 
 [package*.json]
 indent_size = 2
+
+[*.{yaml,yml}]
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Run linter
+      - name: Lint Code
         run: |
           npm run check-codestyle
+
+      - name: Lint Text
+        run: npm run check-text

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Where `options` is an object and can contain the following:
     * Set tags that are common to all metrics.
 * `reporter`: An object that actually sends the buffered metrics. (optional)
     * There are two built-in reporters you can use:
-        1. `reporters.DataDogReporter` sends metrics to DataDog’s API, and is
+        1. `reporters.DataDogReporter` sends metrics to Datadog’s API, and is
            the default.
         2. `reporters.NullReporter` throws the metrics away. It’s useful for
            tests or temporarily disabling your metrics.
@@ -217,9 +217,9 @@ metrics.histogram('test.service_time', 0.248, ['tag:value'], Date.now(), {
 
 Send a distribution value. Distributions are similar to histograms (they create
 several metrics for count, average, percentiles, etc.), but they are calculated
-server-side on DataDog’s systems. This is much higher-overhead than histograms,
+server-side on Datadog’s systems. This is much higher-overhead than histograms,
 and the individual calculations made from it have to be configured on the
-DataDog website instead of in the options for this package.
+Datadog website instead of in the options for this package.
 
 You should use this in environments where you have many instances of your
 application running in parallel, or instances constantly starting and stopping
@@ -275,9 +275,9 @@ npm test
         metrics.distribution('my.metric.name', 3.8, ['tags:here']);
         ```
 
-        Distributions are similar to histograms (they create several metrics for count, average, percentiles, etc.), but they are calculated server-side on DataDog’s systems. For more details and guidance on when to use them, see:
+        Distributions are similar to histograms (they create several metrics for count, average, percentiles, etc.), but they are calculated server-side on Datadog’s systems. For more details and guidance on when to use them, see:
         * The documentation in this project’s README
-        * DataDog’s documentation at https://docs.datadoghq.com/metrics/distributions/
+        * Datadog’s documentation at https://docs.datadoghq.com/metrics/distributions/
 
         (Thanks to @Mr0grog.)
 
@@ -355,7 +355,7 @@ npm test
 
 * 0.9.0 (2021-02-10)
     * Clean up continuous integration tooling on TravisCI. (Thanks to @rpelliard.)
-    * Correct “DataDog” to “Datadog” throughout the documentation. It turns out there’s not supposed to be a captial D in the middle. (Thanks to @dbenamy.)
+    * Correct “Datadog” throughout the documentation. It turns out there’s not supposed to be a captial D in the middle. (Thanks to @dbenamy.)
     * INTERNAL: Add internal support for submitting metrics to different Datadog sites (e.g. `datadoghq.eu` for Europe). (Thanks to @fermelone.)
     * [View diff](https://github.com/dbader/node-datadog-metrics/compare/ebb4bf701f700841e8b5c5325165f13397249b51...e58b13055b803a9c4f4c7b2426e3784b8fd4e0ae)
 

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ let sharedLogger = null;
 //
 // opts may include:
 //
-//     - apiKey: DataDog API key
-//     - appKey: DataDog APP key
+//     - apiKey: Datadog API key
+//     - appKey: Datadog APP key
 //     - host: Default host for all reported metrics
 //     - prefix: Default key prefix for all metrics
 //     - defaultTags: Common tags for all metrics

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -12,20 +12,20 @@ const Distribution = require('./metrics').Distribution;
 // --- BufferedMetricsLogger
 //
 
-// This talks to the DataDog HTTP API to log a bunch of metrics.
+// This talks to the Datadog HTTP API to log a bunch of metrics.
 //
 // Because we don't want to fire off an HTTP request for each data point
 // this buffers all metrics in the given time slice and periodically
-// flushes them to DataDog.
+// flushes them to Datadog.
 //
-// Look here if you want to learn more about the DataDog API:
+// Look here if you want to learn more about the Datadog API:
 // >> http://docs.datadoghq.com/guides/metrics/ <<
 //
 //
 // `opts` may include:
 //
-//     - apiKey: DataDog API key
-//     - appKey: DataDog APP key
+//     - apiKey: Datadog API key
+//     - appKey: Datadog APP key
 //     - host: Default host for all reported metrics
 //     - prefix: Default key prefix for all metrics
 //     - apiHost: Datadog API host (also called "site" in Datadog docs)
@@ -91,7 +91,7 @@ BufferedMetricsLogger.prototype.distribution = function(key, value, tags, timest
 BufferedMetricsLogger.prototype.flush = function(onSuccess, onError) {
     const series = this.aggregator.flush();
     if (series.length > 0) {
-        debug('Flushing %d metrics to DataDog', series.length);
+        debug('Flushing %d metrics to Datadog', series.length);
         this.reporter.report(series, onSuccess, onError);
     } else {
         debug('Nothing to flush');

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -203,7 +203,7 @@ Histogram.prototype.median = function(sortedSamples) {
 //
 // DISTRIBUTION
 // ------------
-// Similar to a histogram, but sends every point to DataDog and does the
+// Similar to a histogram, but sends every point to Datadog and does the
 // calculations server-side.
 //
 // This is higher overhead than Counter or Histogram, but is particularly useful

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datadog-metrics",
   "version": "0.10.1",
-  "description": "Buffered metrics reporting via the DataDog HTTP API",
+  "description": "Buffered metrics reporting via the Datadog HTTP API",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   },
   "scripts": {
     "test": "mocha --reporter spec",
-    "check-codestyle": "jshint --reporter node_modules/jshint-stylish-ex/stylish.js *.js ./lib/*.js ./test/*.js && jscs --config .jscsrc *.js ./lib/*.js ./test/*.js"
+    "check-codestyle": "npm run check-codestyle:jshint && npm run check-codestyle:jscs",
+    "check-codestyle:jscs": "jscs --config .jscsrc *.js ./lib/*.js ./test/*.js",
+    "check-codestyle:jshint": "jshint --reporter node_modules/jshint-stylish-ex/stylish.js *.js ./lib/*.js ./test/*.js",
+    "check-text": "test/lint_text.sh"
   },
   "keywords": [
     "datadog",

--- a/test/lint_text.sh
+++ b/test/lint_text.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Find and log lines with "DataDog" or "dataDog", but allow "DataDogReporter"
+# and "github.com/DataDog", etc. This uses grep to find all lines with
+# "DataDog", then awk to filter out the lines that only have allowed patterns
+# (but not the lines that have both allowed patterns and "DataDog").
+#
+# This could be done in one step with negative lookahead assertions in grep,
+# but that requires PCRE2, and many people have grep without PCRE2 support.
+bad_lines=$(
+    grep                           \
+        -r                         \
+        --exclude lint_text.sh     \
+        --exclude-dir node_modules \
+        --exclude-dir .git         \
+        --line-number              \
+        --extended-regexp          \
+        '[dD]ataDog'               \
+        .                          \
+        | awk '
+            # Store the raw line then remove allowed patterns before processing.
+            {raw_line=$0; gsub(/DataDogReporter|github\.com\/DataDog/,"")}
+            # Print every line that has DataDog in it.
+            /[dD]ataDog/ {print raw_line}
+        '
+)
+
+if [ -n "${bad_lines}" ]; then
+    echo 'The correct spelling of "Datadog" does not capitalize the second "D".'
+    echo 'Please fix these lines ("DataDogReporter" is allowed):'
+    echo ''
+    echo "${bad_lines}"
+    echo ''
+
+    line_count=$(echo "${bad_lines}" | wc -l | sed 's/[[:space:]]//g')
+    echo "$line_count errors."
+
+    exit 1
+fi


### PR DESCRIPTION
In #59, @dbenamy fixed a number of places where the text "DataDog" (incorrect) was used instead of "Datadog" (correct). People have since added more incorrect usages (many from me!), so this adds a quick script to log an error during linting to prevent re-introducing the problem.

It outputs something like ([live example](https://github.com/dbader/node-datadog-metrics/actions/runs/3119206487/jobs/5059019139)):

```
The correct spelling of "Datadog" does not capitalize the second "D".
Please fix these lines ("DataDogReporter" is allowed):

./index.js:10://     - apiKey: DataDog API key
./index.js:11://     - appKey: DataDog APP key
./lib/loggers.js:15:// This talks to the DataDog HTTP API to log a bunch of metrics.
./lib/loggers.js:19:// flushes them to DataDog.
./lib/loggers.js:21:// Look here if you want to learn more about the DataDog API:
./lib/loggers.js:27://     - apiKey: DataDog API key
./lib/loggers.js:28://     - appKey: DataDog APP key
./lib/loggers.js:94:        debug('Flushing %d metrics to DataDog', series.length);
./lib/metrics.js:206:// Similar to a histogram, but sends every point to DataDog and does the
./package.json:4:  "description": "Buffered metrics reporting via the DataDog HTTP API",
./README.md:132:        1. `reporters.DataDogReporter` sends metrics to DataDog’s API, and is
./README.md:220:server-side on DataDog’s systems. This is much higher-overhead than histograms,
./README.md:222:DataDog website instead of in the options for this package.
./README.md:278:        Distributions are similar to histograms (they create several metrics for count, average, percentiles, etc.), but they are calculated server-side on DataDog’s systems. For more details and guidance on when to use them, see:
./README.md:280:        * DataDog’s documentation at https://docs.datadoghq.com/metrics/distributions/
./README.md:358:    * Correct “DataDog” to “Datadog” throughout the documentation. It turns out there’s not supposed to be a captial D in the middle. (Thanks to @dbenamy.)

16 errors.
```

(Although hopefully on future PRs it will be shorter!)

*Edit: fixed bad paste in example above.*