### PR TITLE
Be more noisy about errors and add an `onError` option

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -20,8 +20,9 @@
     //
     // Setting to true ENABLES a check
 
-    // Enforce === instead of ==
+    // Enforce === instead of ==, except when comparing to `null`.
     "eqeqeq": true,
+    "eqnull": true,
     // Force hasOwnProperty checks within `for in`
     "forin": true,
     // Prohibits overwriting native types like `Array` or `Date`

--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ var metricsLogger = new metrics.BufferedMetricsLogger({
     host: 'myhost',
     prefix: 'myapp.',
     flushIntervalSeconds: 15,
-    defaultTags: ['env:staging', 'region:us-east-1']
+    defaultTags: ['env:staging', 'region:us-east-1'],
+    onError (error) {
+        console.error('There was an error auto-flushing metrics:', error);
+    }
 });
 metricsLogger.gauge('mygauge', 42);
 ```
@@ -127,6 +130,11 @@ Where `options` is an object and can contain the following:
       Datadog-metrics looks for the APP key in `DATADOG_APP_KEY` by default.
 * `defaultTags`: Default tags used for all metric reporting. (optional)
     * Set tags that are common to all metrics.
+* `onError`: A function to call when there are asynchronous errors seding
+    buffered metrics to Datadog. It takes one argument (the error). (optional)
+    * If the error was not handled (either by setting this option or by
+      specifying a handler when manually calling `flush()`), the error will be
+      logged to stdout.
 * `reporter`: An object that actually sends the buffered metrics. (optional)
     * There are two built-in reporters you can use:
         1. `reporters.DataDogReporter` sends metrics to Datadog’s API, and is
@@ -280,6 +288,17 @@ npm test
         * Datadog’s documentation at https://docs.datadoghq.com/metrics/distributions/
 
         (Thanks to @Mr0grog.)
+
+    * Add an `onError` option for handling asynchronous errors while flushing. You can use this to get details on an error or to send error info to another error tracking service like Sentry.io:
+
+        ```js
+        const metrics = require('datadog-metrics');
+        metrics.init({
+            onError (error) {
+                console.error('There was an error sending to Datadog:', error);
+            }
+        });
+        ```
 
     * Expose built-in reporter classes for public use. If you need to disable the metrics library for some reason, you can now do so with:
 

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -1,6 +1,5 @@
 'use strict';
-const debug = require('debug')('metrics');
-
+const { logDebug } = require('./logging');
 const Aggregator = require('./aggregators').Aggregator;
 const DataDogReporter = require('./reporters').DataDogReporter;
 const Gauge = require('./metrics').Gauge;
@@ -51,9 +50,9 @@ function BufferedMetricsLogger(opts) {
     }
 
     if (this.flushIntervalSeconds) {
-        debug('Auto-flushing every %d seconds', this.flushIntervalSeconds);
+        logDebug('Auto-flushing every %d seconds', this.flushIntervalSeconds);
     } else {
-        debug('Auto-flushing is disabled');
+        logDebug('Auto-flushing is disabled');
     }
 
     const autoFlushCallback = () => {
@@ -97,10 +96,10 @@ BufferedMetricsLogger.prototype.distribution = function(key, value, tags, timest
 BufferedMetricsLogger.prototype.flush = function(onSuccess, onError) {
     const series = this.aggregator.flush();
     if (series.length > 0) {
-        debug('Flushing %d metrics to Datadog', series.length);
+        logDebug('Flushing %d metrics to Datadog', series.length);
         this.reporter.report(series, onSuccess, onError || this.onError);
     } else {
-        debug('Nothing to flush');
+        logDebug('Nothing to flush');
         if (typeof onSuccess === 'function') {
             onSuccess();
         }

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -44,6 +44,12 @@ function BufferedMetricsLogger(opts) {
     this.prefix = opts.prefix || '';
     this.flushIntervalSeconds = opts.flushIntervalSeconds;
 
+    if (typeof opts.onError === 'function') {
+        this.onError = opts.onError;
+    } else if (opts.onError != null) {
+        throw new TypeError(`The 'onError' option must be a function`);
+    }
+
     if (this.flushIntervalSeconds) {
         debug('Auto-flushing every %d seconds', this.flushIntervalSeconds);
     } else {
@@ -92,7 +98,7 @@ BufferedMetricsLogger.prototype.flush = function(onSuccess, onError) {
     const series = this.aggregator.flush();
     if (series.length > 0) {
         debug('Flushing %d metrics to Datadog', series.length);
-        this.reporter.report(series, onSuccess, onError);
+        this.reporter.report(series, onSuccess, onError || this.onError);
     } else {
         debug('Nothing to flush');
         if (typeof onSuccess === 'function') {

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const util = require('util');
+const debug = require('debug');
+
+const prefix = 'metrics';
+
+/**
+ * A prefixed instance of the `debug` logger. You can call this directly, or
+ * call `extend()` on it to create a nested logger.
+ * @type {debug.Debugger}
+ */
+const logDebug = debug(prefix);
+
+/**
+ * Logs an error object or message to stderr. Unlike `logDebug()`, this will
+ * always print output, so should only be used for significant failures users
+ * *need* to know about.
+ * @param {string|Error} error The error to log.
+ */
+function logError(error, ...extra) {
+    if (typeof error === 'string') {
+        const message = util.format(error, ...extra);
+        console.error(`${prefix}: ERROR: ${message}`);
+    } else {
+        console.error(`${prefix}:`, error);
+    }
+}
+
+module.exports = {
+    logDebug,
+    logError
+};

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -1,6 +1,6 @@
 'use strict';
-const debug = require('debug')('metrics');
 const datadogApiClient = require('@datadog/datadog-api-client');
+const { logDebug, logError } = require('./logging');
 
 //
 // NullReporter
@@ -51,10 +51,7 @@ function DataDogReporter(apiKey, appKey, apiHost) {
 }
 
 DataDogReporter.prototype.report = function(series, onSuccess, onError) {
-    if (debug.enabled) {
-        // Only call stringify when debugging.
-        debug('Calling report with %s', JSON.stringify(series));
-    }
+    logDebug('Calling report with %j', series);
 
     // Distributions must be submitted via a different method than other
     // metrics, so split them up.
@@ -84,15 +81,16 @@ DataDogReporter.prototype.report = function(series, onSuccess, onError) {
 
     Promise.all(submissions)
         .then(() => {
-            debug('sent metrics successfully');
+            logDebug('sent metrics successfully');
             if (typeof onSuccess === 'function') {
                 onSuccess();
             }
         })
         .catch((error) => {
-            debug('ERROR: failed to send metrics (err=%s)', error);
             if (typeof onError === 'function') {
                 onError(error);
+            } else {
+                logError('failed to send metrics (err=%s)', error);
             }
         });
 };

--- a/test/loggers_tests.js
+++ b/test/loggers_tests.js
@@ -172,6 +172,25 @@ describe('BufferedMetricsLogger', function() {
         );
     });
 
+    it('should support the `onError` option', function(done) {
+        nock('https://api.datadoghq.com')
+            .post('/api/v1/series')
+            .reply(403, { errors: ['Forbidden'] });
+
+        const logger = new BufferedMetricsLogger({
+            apiKey: 'not-valid',
+            onError (error) {
+                if (error) {
+                    done();
+                } else {
+                    done(new Error('Handler was called without error data'));
+                }
+            }
+        });
+        logger.gauge('test.gauge', 23);
+        logger.flush();
+    });
+
     it('should allow two instances to use different credentials', function(done) {
         const apiKeys = ['abc', 'xyz'];
         let receivedKeys = [];


### PR DESCRIPTION
This fixes #52 by making two changes:

1. Add an `onError` option where users can provide an error handler for auto-flushes, just like they do when calling `flush()` explicitly. This is useful for getting more detail about the error, doing custom logging, or sending the error to a separate error tracking service, like Sentry.io.

2. In cases where the error was not handled (either via the `onError` option or by manually calling `flush()` with an error handler), this logs the error to the console *regardless* of the environment’s `DEBUG` setting. This particular error is a pretty big deal and should not be silenced.

I did the second change by making a special logging function for errors, since `debug` does not have a concept of levels or any way to temporarily override the environment (you can call `enable()`, but that overrides whatever was set before, so you can’t just put things back the way they were once you do that).