### PR TITLE
Add a histogram option

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ Where `options` is an object and can contain the following:
     * If the error was not handled (either by setting this option or by
       specifying a handler when manually calling `flush()`), the error will be
       logged to stdout.
+* `histogram`: An object with default options for all histograms. This has the
+    same properties as the options object on the `histogram()` method. Options
+    specified when calling the method are layered on top of this object.
+    (optional)
 * `reporter`: An object that actually sends the buffered metrics. (optional)
     * There are two built-in reporters you can use:
         1. `reporters.DataDogReporter` sends metrics to Datadog’s API, and is
@@ -308,6 +312,30 @@ npm test
             reporter: new metrics.reporters.NullReporter((flushedMetrics) => {
                 // Optional callback to be notified when metrics are flushed.
             }),
+        });
+        ```
+
+        (Thanks to @Mr0grog.)
+
+    * Add an option for setting histogram defaults. In v0.10.0, the `histogram()` function gained the ability to set what aggregations and percentiles it generates with a final `options` argument. You can now specify a `histogram` option for `init()` or `BufferedMetricsLogger` in order to set default options for all calls to `histogram()`. Any options you set in the actual `histogram()` call will layer on top of the defaults:
+
+        ```js
+        const metrics = require('datadog-metrics');
+        metrics.init({
+            histogram: {
+                aggregations: ['sum', 'avg'],
+                percentiles: [0.99]
+            }
+        });
+
+        // Acts as if the options had been set to:
+        // { aggregations: ['sum', 'avg'], percentiles: [0.99] }
+        metrics.histogram('my.metric.name', 3.8);
+
+        // Acts as if the options had been set to:
+        // { aggregations: ['sum', 'avg'], percentiles: [0.5, 0.95] }
+        metrics.histogram('my.metric.name', 3.8, [], Date.now(), {
+            percentiles: [0.5, 0.95]
         });
         ```
 

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -29,6 +29,10 @@ const Distribution = require('./metrics').Distribution;
 //     - prefix: Default key prefix for all metrics
 //     - apiHost: Datadog API host (also called "site" in Datadog docs)
 //     - flushIntervalSeconds:
+//     - histogram: Default options for all histograms. This has the same
+//       properties as the options object on the `histogram()` method, and the
+//       options specified when calling the method are layered on top of these
+//       defaults.
 //
 // You can also use it to override (dependency-inject) the aggregator
 // and reporter instance, which is useful for testing:
@@ -42,6 +46,7 @@ function BufferedMetricsLogger(opts) {
     this.host = opts.host;
     this.prefix = opts.prefix || '';
     this.flushIntervalSeconds = opts.flushIntervalSeconds;
+    this.histogramOptions = opts.histogram;
 
     if (typeof opts.onError === 'function') {
         this.onError = opts.onError;
@@ -86,7 +91,10 @@ BufferedMetricsLogger.prototype.increment = function(key, value, tags, timestamp
 };
 
 BufferedMetricsLogger.prototype.histogram = function(key, value, tags, timestampInMillis, options = {}) {
-    this.addPoint(Histogram, key, value, tags, timestampInMillis, options);
+    this.addPoint(Histogram, key, value, tags, timestampInMillis, {
+        ...this.histogramOptions,
+        ...options
+    });
 };
 
 BufferedMetricsLogger.prototype.distribution = function(key, value, tags, timestampInMillis) {

--- a/test/loggers_tests.js
+++ b/test/loggers_tests.js
@@ -96,6 +96,41 @@ describe('BufferedMetricsLogger', function() {
         l.histogram('test.histogram', 23, ['a:a'], 1234567890);
     });
 
+    it('should support setting options for histograms', function() {
+        const l = new BufferedMetricsLogger({
+            reporter: new reporters.NullReporter()
+        });
+        l.histogram('test.histogram', 23, ['a:a'], 1234567890, {
+            percentiles: [0.5]
+        });
+
+        const f = l.aggregator.flush();
+        const percentiles = f.filter(x => x.metric.endsWith('percentile'));
+        percentiles.should.have.lengthOf(1);
+        percentiles.should.have.nested.property(
+            '[0].metric',
+            'test.histogram.50percentile'
+        );
+    });
+
+    it('should support the `histogram` option', function() {
+        const l = new BufferedMetricsLogger({
+            reporter: new reporters.NullReporter(),
+            histogram: {
+                percentiles: [0.5]
+            }
+        });
+        l.histogram('test.histogram', 23);
+
+        const f = l.aggregator.flush();
+        const percentiles = f.filter(x => x.metric.endsWith('percentile'));
+        percentiles.should.have.lengthOf(1);
+        percentiles.should.have.nested.property(
+            '[0].metric',
+            'test.histogram.50percentile'
+        );
+    });
+
     it('should allow setting a default host', function() {
         const l = new BufferedMetricsLogger({
             reporter: new reporters.NullReporter(),


### PR DESCRIPTION
This adds a `histogram` option to `init()` and `BufferedMetricsLogger` that provides a default options object for all calls to the `histogram()` method. Any options provided in the actual method call layer on top of and get combined with these defaults:

```js
const metrics = require('datadog-metrics');
metrics.init({
    histogram: {
        aggregations: ['sum', 'avg'],
        percentiles: [0.99]
    }
});

// Provides options when none are explicitly set on a histogram.
// Acts as if the options had been set to:
//   { aggregations: ['sum', 'avg'], percentiles: [0.99] }
metrics.histogram('my.metric.name', 3.8);

// Combines with options that are explicitly set on a given histogram.
// Acts as if the options had been set to:
//   { aggregations: ['sum', 'avg'], percentiles: [0.5, 0.95] }
metrics.histogram('my.metric.name', 3.8, [], Date.now(), {
    percentiles: [0.5, 0.95]
});
```

I *think* `histogram` is a clear and concise name for this option, but am certainly happy to change if anyone thinks it should be something else, like `histogramOptions`, `histogramDefaults`, etc.

Fixes #88.