### PR TITLE
Undefined error with env variable DATADOG_API_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ npm test
     * This package no longer locks specific versions of its dependencies (instead, your package manager can choose any version that is compatible). This may help when deduplicating packages for faster installs or smaller bundles. (Thanks to @Mr0grog.)
 
     * FIX: Don’t use `unref()` on timers in non-Node.js environments. This is a step towards browser compatibility, although we are not testing browser-based usage yet. (Thanks to @Mr0grog.)
-    * FIX: The `apiHost` option was broken in v0.10.0 and now works again. (Thanks to @Mr0grog.)
+    * FIX: The `apiHost` option was broken in v0.10.0 and now works again. (Thanks to @Mr0grog, @npeters.)
     * FIX: Creating a second instance of `BufferedMetricsLogger` will not longer change the credentials used by previously created `BufferedMetricsLogger` instances.
     * INTERNAL: Renamed the default branch in this repo to `main`. (Thanks to @dbader.)
     * INTERNAL: Use GitHub actions for continuous integration. (Thanks to @Mr0grog.)

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -42,7 +42,7 @@ function DataDogReporter(apiKey, appKey, apiHost) {
         // Strip leading `app.` from the site in case someone copy/pasted the
         // URL from their web browser. More details on correct configuration:
         // https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
-        this.apiHost = apiHost.replace(/^app\./i, '');
+        this.apiHost = this.apiHost.replace(/^app\./i, '');
         datadogApiClient.client.setServerVariables(configuration, {
             site: this.apiHost
         });


### PR DESCRIPTION
undefined error with env variable DATADOG_API_HOST:

github/node-datadog-metrics/lib/reporters.js:45
        this.apiHost = apiHost.replace(/^app\./i, '');
                               ^

TypeError: Cannot read properties of undefined (reading 'replace')
    at new DataDogReporter (github/node-datadog-metrics/lib/reporters.js:45:32)
    at new BufferedMetricsLogger (github/node-datadog-metrics/lib/loggers.js:45:38)
    at Object.init (github/node-datadog-metrics/index.js:28:20)
    at Object.<anonymous> (github/node-datadog-metrics/examples/metrics.js:4:9)
    at Module._compile (node:internal/modules/cjs/loader:1119:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1173:10)
    at Module.load (node:internal/modules/cjs/loader:997:32)
    at Module._load (node:internal/modules/cjs/loader:838:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:18:47