### PR TITLE
Publish TypeScript types, user newer class syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,23 @@ jobs:
 
       - name: Lint Text
         run: npm run check-text
+
+  types:
+    name: Build/Check Types
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: '**/package.json'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Types
+        run: |
+          npm run build-types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 on:
   pull_request: {}
-  push: {}
+  push:
+    branches:
+      - main
 
 name: Continuous Integration
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ coverage
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
+# Type Definitions
+dist
+
 # Dependency directory
 # Commenting this out is preferred by some people, see
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ metrics.init({ host: 'myhost', reporter: metrics.NullReporter() });
 
 `metrics.gauge(key, value[, tags[, timestamp]])`
 
-Record the current *value* of a metric. They most recent value in
+Record the current *value* of a metric. The most recent value in
 a given flush interval will be recorded. Optionally, specify a set of
 tags to associate with the metric. This should be used for sum values
 such as total hard disk space, process uptime, total number of active

--- a/index.js
+++ b/index.js
@@ -4,22 +4,14 @@ const reporters = require('./lib/reporters');
 
 let sharedLogger = null;
 
-//
-// opts may include:
-//
-//     - apiKey: Datadog API key
-//     - appKey: Datadog APP key
-//     - host: Default host for all reported metrics
-//     - prefix: Default key prefix for all metrics
-//     - defaultTags: Common tags for all metrics
-//     - flushIntervalSeconds:
-//
-// You can also use it to override (dependency-inject) the aggregator
-// and reporter instance, which is useful for testing:
-//
-//     - aggregator: an Aggregator instance
-//     - reporter: a Reporter instance
-//
+/**
+ * Configure the datadog-metrics library.
+ *
+ * Any settings used here will apply to the top-level metrics functions (e.g.
+ * `increment()`, `gauge()`). If you need multiple separate configurations, use
+ * the `BufferedMetricsLogger` class.
+ * @param {loggers.BufferedMetricsLoggerOptions} [opts]
+ */
 function init(opts) {
     opts = opts || {};
     if (!opts.flushIntervalSeconds && opts.flushIntervalSeconds !== 0) {
@@ -39,7 +31,7 @@ function callOnSharedLogger(funcName) {
 }
 
 module.exports = {
-    init: init,
+    init,
     flush: callOnSharedLogger.bind(undefined, 'flush'),
     gauge: callOnSharedLogger.bind(undefined, 'gauge'),
     increment: callOnSharedLogger.bind(undefined, 'increment'),
@@ -48,5 +40,5 @@ module.exports = {
 
     BufferedMetricsLogger: loggers.BufferedMetricsLogger,
 
-    reporters: reporters
+    reporters
 };

--- a/lib/aggregators.js
+++ b/lib/aggregators.js
@@ -1,45 +1,48 @@
 'use strict';
 
-//
-// --- Aggregator
-//
-
-function Aggregator(defaultTags) {
-    this.buffer = {};
-    this.defaultTags = defaultTags || [];
-}
-
-Aggregator.prototype.makeBufferKey = function(key, tags) {
-    tags = tags || [''];
-    return key + '#' + tags.concat().sort().join('.');
-};
-
-Aggregator.prototype.addPoint = function(Type, key, value, tags, host, timestampInMillis, options) {
-    const bufferKey = this.makeBufferKey(key, tags);
-    if (!Object.prototype.hasOwnProperty.call(this.buffer, bufferKey)) {
-        this.buffer[bufferKey] = new Type(key, tags, host, options);
+class Aggregator {
+    /**
+     * Create an aggregator to group and buffer metric objects.
+     * @param {string[]} defaultTags
+     */
+    constructor(defaultTags) {
+        this.buffer = {};
+        this.defaultTags = defaultTags || [];
     }
 
-    this.buffer[bufferKey].addPoint(value, timestampInMillis);
-};
-
-Aggregator.prototype.flush = function() {
-    let series = [];
-    for (const item of Object.values(this.buffer)) {
-        series.push(...item.flush());
+    /** @protected */
+    makeBufferKey(key, tags) {
+        tags = tags || [''];
+        return key + '#' + tags.concat().sort().join('.');
     }
 
-    // Add default tags
-    if (this.defaultTags) {
-        for (const metric of series) {
-            metric.tags.unshift(...this.defaultTags);
+    addPoint(Type, key, value, tags, host, timestampInMillis, options) {
+        const bufferKey = this.makeBufferKey(key, tags);
+        if (!Object.prototype.hasOwnProperty.call(this.buffer, bufferKey)) {
+            this.buffer[bufferKey] = new Type(key, tags, host, options);
         }
+
+        this.buffer[bufferKey].addPoint(value, timestampInMillis);
     }
 
-    this.buffer = {};
+    flush() {
+        let series = [];
+        for (const item of Object.values(this.buffer)) {
+            series.push(...item.flush());
+        }
 
-    return series;
-};
+        // Add default tags
+        if (this.defaultTags) {
+            for (const metric of series) {
+                metric.tags.unshift(...this.defaultTags);
+            }
+        }
+
+        this.buffer = {};
+
+        return series;
+    }
+}
 
 module.exports = {
     Aggregator

--- a/lib/aggregators.js
+++ b/lib/aggregators.js
@@ -42,5 +42,5 @@ Aggregator.prototype.flush = function() {
 };
 
 module.exports = {
-    Aggregator: Aggregator
+    Aggregator
 };

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -75,7 +75,7 @@ class BufferedMetricsLogger {
      */
     constructor (opts) {
         /** @private */
-        this.aggregator = opts.aggregator || new Aggregator(opts.defaultTags, 'extra-arg');
+        this.aggregator = opts.aggregator || new Aggregator(opts.defaultTags);
         /** @private */
         this.reporter = opts.reporter || new DataDogReporter(opts.apiKey, opts.appKey, opts.apiHost);
         /** @private */

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -7,48 +7,84 @@ const Counter = require('./metrics').Counter;
 const Histogram = require('./metrics').Histogram;
 const Distribution = require('./metrics').Distribution;
 
-//
-// --- BufferedMetricsLogger
-//
+/**
+ * @typedef {object} AggregatorType Buffers metrics to send.
+ * @property {(
+ *              type: Function,
+ *              key: string,
+ *              value: number,
+ *              tags: string[],
+ *              host: string,
+ *              timestampInMillis: number,
+ *              options: any
+ *           ) => void} addPoint Call this function to add a data point to the
+ *           aggregator. The `type` parameter is a metric class to use.
+ * @property {() => any[]} flush Returns an array of API-formatted metric
+ *           objects ready to be sent to a reporter.
+ */
 
-// This talks to the Datadog HTTP API to log a bunch of metrics.
-//
-// Because we don't want to fire off an HTTP request for each data point
-// this buffers all metrics in the given time slice and periodically
-// flushes them to Datadog.
-//
-// Look here if you want to learn more about the Datadog API:
-// >> http://docs.datadoghq.com/guides/metrics/ <<
-//
-//
-// `opts` may include:
-//
-//     - apiKey: Datadog API key
-//     - appKey: Datadog APP key
-//     - host: Default host for all reported metrics
-//     - prefix: Default key prefix for all metrics
-//     - apiHost: Datadog API host (also called "site" in Datadog docs)
-//     - flushIntervalSeconds:
-//     - histogram: Default options for all histograms. This has the same
-//       properties as the options object on the `histogram()` method, and the
-//       options specified when calling the method are layered on top of these
-//       defaults.
-//
-// You can also use it to override (dependency-inject) the aggregator
-// and reporter instance, which is useful for testing:
-//
-//     - aggregator: an Aggregator instance
-//     - reporter: a Reporter instance
-//
+/**
+ * @typedef {object} ReporterType
+ * @property {(series: any[], onSuccess?: Function, onError?: Function) => void} report
+ */
+
+/**
+ * @typedef {object} BufferedMetricsLoggerOptions
+ * @property {string} [apiKey] Datadog API key
+ * @property {string} [appKey] Datadog APP key
+ * @property {string} [host] Default host for all reported metrics
+ * @property {string} [prefix] Default key prefix for all metrics
+ * @property {string} [apiHost] Sets the Datadog "site", or server where metrics
+ *           are sent. For details and options, see:
+ *           https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
+ * @property {number} [flushIntervalSeconds] How often to send metrics to
+ *           Datadog (in seconds).
+ * @property {string[]} [defaultTags] Default tags used for all metrics.
+ * @property {object} [histogram] Default options for histograms.
+ * @property {string[]} [histogram.aggregations] A list of aggregations to
+ *           to create metrics for on histograms. Values can be any of:
+ *           'max', 'min', 'sum', 'avg', 'count', or 'median'.
+ * @property {number[]} [histogram.percentiles] A list of percentiles to create
+ *           metrics for on histograms. Each value must be a number between 0
+ *           and 1. For example, to create 50th and 90th percentile metrics for
+ *           each histogram, set this option to `[0.5, 0.9]`.
+ * @property {(error: any) => void} [onError] A function to call when there are
+ *           asynchronous errors sending metrics. It takes one argument --
+ *           the error.
+ * @property {AggregatorType} [aggregator] An aggregator instance for buffering
+ *           metrics between flushes.
+ * @property {ReporterType} [reporter] An object that actually sends the
+ *           buffered metrics.
+ */
+
+/**
+ * BufferedMetricsLogger manages the buffering and sending of metrics to Datadog
+ * and provides convenience methods for logging those metrics.
+ *
+ * Because you don't want to send an HTTP request for each data point, this
+ * buffers all metrics in a given time period before sending them to Datadog
+ * in one batch (you can adjust this with the `flushIntervalSeconds` option).
+ *
+ * For more about the API, see: http://docs.datadoghq.com/guides/metrics/
+ * @constructor
+ * @param {BufferedMetricsLoggerOptions} [opts]
+ */
 function BufferedMetricsLogger(opts) {
+    /** @private */
     this.aggregator = opts.aggregator || new Aggregator(opts.defaultTags);
+    /** @private */
     this.reporter = opts.reporter || new DataDogReporter(opts.apiKey, opts.appKey, opts.apiHost);
+    /** @private */
     this.host = opts.host;
+    /** @private */
     this.prefix = opts.prefix || '';
+    /** @private */
     this.flushIntervalSeconds = opts.flushIntervalSeconds;
+    /** @private */
     this.histogramOptions = opts.histogram;
 
     if (typeof opts.onError === 'function') {
+        /** @private */
         this.onError = opts.onError;
     } else if (opts.onError != null) {
         throw new TypeError('The `onError` option must be a function');
@@ -73,15 +109,52 @@ function BufferedMetricsLogger(opts) {
     autoFlushCallback();
 }
 
-// Prepend the global key prefix and set the default host.
+/**
+ * Prepend the global key prefix and set the default host.
+ * @private
+ */
 BufferedMetricsLogger.prototype.addPoint = function(Type, key, value, tags, timestampInMillis, options) {
     this.aggregator.addPoint(Type, this.prefix + key, value, tags, this.host, timestampInMillis, options);
 };
 
+/**
+ * Record the current *value* of a metric. When flushed, a gauge reports only
+ * the most recent value, ignoring any other values recorded since the last
+ * flush.
+ *
+ * Optionally, specify a set of tags to associate with the metric. This should
+ * be continuously varying values such as total hard disk space, process uptime,
+ * total number of active users, or number of rows in a database table. The
+ * optional timestamp is in milliseconds since 1 Jan 1970 00:00:00 UTC,
+ * e.g. from `Date.now()`.
+ *
+ * @param {string} key
+ * @param {number} value
+ * @param {string[]} [tags]
+ * @param {number} [timestampInMillis]
+ *
+ * @example
+ * metrics.gauge('test.mem_free', 23);
+ */
 BufferedMetricsLogger.prototype.gauge = function(key, value, tags, timestampInMillis) {
     this.addPoint(Gauge, key, value, tags, timestampInMillis);
 };
 
+/**
+ * Increment the counter by the given *value* (or `1` by default). Optionally,
+ * specify a list of *tags* to associate with the metric. This is useful for
+ * counting things such as incrementing a counter each time a page is requested.
+ * The optional timestamp is in milliseconds since 1 Jan 1970 00:00:00 UTC,
+ * e.g. from `Date.now()`.
+ * @param {string} key
+ * @param {number} [value]
+ * @param {string[]} [tags]
+ * @param {number} [timestampInMillis]
+ *
+ * @example
+ * metrics.increment('test.requests_served');
+ * metrics.increment('test.awesomeness_factor', 10);
+ */
 BufferedMetricsLogger.prototype.increment = function(key, value, tags, timestampInMillis) {
     if (value === undefined || value === null) {
         this.addPoint(Counter, key, 1, tags, timestampInMillis);
@@ -90,6 +163,31 @@ BufferedMetricsLogger.prototype.increment = function(key, value, tags, timestamp
     }
 };
 
+/**
+ * Sample a histogram value. Histograms will produce metrics that
+ * describe the distribution of the recorded values, namely the minimum,
+ * maximum, average, median, count and the 75th, 85th, 95th and 99th percentiles.
+ * Optionally, specify a list of *tags* to associate with the metric.
+ * The optional timestamp is in milliseconds since 1 Jan 1970 00:00:00 UTC,
+ * e.g. from `Date.now()`.
+ * @param {string} key
+ * @param {number} value
+ * @param {string[]} [tags]
+ * @param {number} [timestampInMillis]
+ * @param {any} [options]
+ *
+ * @example
+ * metrics.histogram('test.service_time', 0.248);
+ *
+ * @example
+ * // Set custom options:
+ * metrics.histogram('test.service_time', 0.248, ['tag:value'], Date.now(), {
+ *     // Aggregates can include 'max', 'min', 'sum', 'avg', 'median', or 'count'.
+ *     aggregates: ['avg', 'count'],
+ *     // Percentiles can include any decimal between 0 and 1.
+ *     percentiles: [0.99]
+ * });
+ */
 BufferedMetricsLogger.prototype.histogram = function(key, value, tags, timestampInMillis, options = {}) {
     this.addPoint(Histogram, key, value, tags, timestampInMillis, {
         ...this.histogramOptions,
@@ -97,10 +195,43 @@ BufferedMetricsLogger.prototype.histogram = function(key, value, tags, timestamp
     });
 };
 
+/**
+ * Send a distribution value. Distributions are similar to histograms (they create
+ * several metrics for count, average, percentiles, etc.), but they are calculated
+ * server-side on Datadog’s systems. This is much higher-overhead than histograms,
+ * and the individual calculations made from it have to be configured on the
+ * Datadog website instead of in the options for this package.
+ *
+ * You should use this in environments where you have many instances of your
+ * application running in parallel, or instances constantly starting and stopping
+ * with different hostnames or identifiers and tagging each one separately is not
+ * feasible. AWS Lambda or serverless functions are a great example of this. In
+ * such environments, you also might want to use a distribution instead of
+ * `increment` or `gauge` (if you have two instances of your app sending those
+ * metrics at the same second, and they are not tagged differently or have
+ * different `host` names, one will overwrite the other — distributions will not).
+ * @param {string} key
+ * @param {number} value
+ * @param {string[]} [tags]
+ * @param {number} [timestampInMillis]
+ *
+ * @example
+ * metrics.distribution('test.service_time', 0.248);
+ */
 BufferedMetricsLogger.prototype.distribution = function(key, value, tags, timestampInMillis) {
     this.addPoint(Distribution, key, value, tags, timestampInMillis);
 };
 
+/**
+ * Calling `flush` sends any buffered metrics to Datadog. Unless you set
+ * `flushIntervalSeconds` to 0 it won't be necessary to call this function.
+ *
+ * It can be useful to trigger a manual flush by calling if you want to
+ * make sure pending metrics have been sent before you quit the application
+ * process, for example.
+ * @param {() => void)} [onSuccess]
+ * @param {(error: Error) => void} [onError]
+ */
 BufferedMetricsLogger.prototype.flush = function(onSuccess, onError) {
     const series = this.aggregator.flush();
     if (series.length > 0) {
@@ -115,5 +246,5 @@ BufferedMetricsLogger.prototype.flush = function(onSuccess, onError) {
 };
 
 module.exports = {
-    BufferedMetricsLogger: BufferedMetricsLogger
+    BufferedMetricsLogger
 };

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -75,7 +75,7 @@ class BufferedMetricsLogger {
      */
     constructor (opts) {
         /** @private */
-        this.aggregator = opts.aggregator || new Aggregator(opts.defaultTags);
+        this.aggregator = opts.aggregator || new Aggregator(opts.defaultTags, 'extra-arg');
         /** @private */
         this.reporter = opts.reporter || new DataDogReporter(opts.apiKey, opts.appKey, opts.apiHost);
         /** @private */

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -60,190 +60,195 @@ const Distribution = require('./metrics').Distribution;
 /**
  * BufferedMetricsLogger manages the buffering and sending of metrics to Datadog
  * and provides convenience methods for logging those metrics.
- *
- * Because you don't want to send an HTTP request for each data point, this
- * buffers all metrics in a given time period before sending them to Datadog
- * in one batch (you can adjust this with the `flushIntervalSeconds` option).
- *
- * For more about the API, see: http://docs.datadoghq.com/guides/metrics/
- * @constructor
- * @param {BufferedMetricsLoggerOptions} [opts]
  */
-function BufferedMetricsLogger(opts) {
-    /** @private */
-    this.aggregator = opts.aggregator || new Aggregator(opts.defaultTags);
-    /** @private */
-    this.reporter = opts.reporter || new DataDogReporter(opts.apiKey, opts.appKey, opts.apiHost);
-    /** @private */
-    this.host = opts.host;
-    /** @private */
-    this.prefix = opts.prefix || '';
-    /** @private */
-    this.flushIntervalSeconds = opts.flushIntervalSeconds;
-    /** @private */
-    this.histogramOptions = opts.histogram;
-
-    if (typeof opts.onError === 'function') {
+class BufferedMetricsLogger {
+    /**
+     * BufferedMetricsLogger manages the buffering and sending of metrics to Datadog
+     * and provides convenience methods for logging those metrics.
+     *
+     * Because you don't want to send an HTTP request for each data point, this
+     * buffers all metrics in a given time period before sending them to Datadog
+     * in one batch (you can adjust this with the `flushIntervalSeconds` option).
+     *
+     * For more about the API, see: http://docs.datadoghq.com/guides/metrics/
+     * @param {BufferedMetricsLoggerOptions} [opts]
+     */
+    constructor (opts) {
         /** @private */
-        this.onError = opts.onError;
-    } else if (opts.onError != null) {
-        throw new TypeError('The `onError` option must be a function');
-    }
+        this.aggregator = opts.aggregator || new Aggregator(opts.defaultTags);
+        /** @private */
+        this.reporter = opts.reporter || new DataDogReporter(opts.apiKey, opts.appKey, opts.apiHost);
+        /** @private */
+        this.host = opts.host;
+        /** @private */
+        this.prefix = opts.prefix || '';
+        /** @private */
+        this.flushIntervalSeconds = opts.flushIntervalSeconds;
+        /** @private */
+        this.histogramOptions = opts.histogram;
 
-    if (this.flushIntervalSeconds) {
-        logDebug('Auto-flushing every %d seconds', this.flushIntervalSeconds);
-    } else {
-        logDebug('Auto-flushing is disabled');
-    }
+        if (typeof opts.onError === 'function') {
+            /** @private */
+            this.onError = opts.onError;
+        } else if (opts.onError != null) {
+            throw new TypeError('The `onError` option must be a function');
+        }
 
-    const autoFlushCallback = () => {
-        this.flush();
         if (this.flushIntervalSeconds) {
-            const interval = this.flushIntervalSeconds * 1000;
-            const tid = setTimeout(autoFlushCallback, interval);
-            // Let the event loop exit if this is the only active timer.
-            if (tid.unref) tid.unref();
+            logDebug('Auto-flushing every %d seconds', this.flushIntervalSeconds);
+        } else {
+            logDebug('Auto-flushing is disabled');
         }
-    };
 
-    autoFlushCallback();
+        const autoFlushCallback = () => {
+            this.flush();
+            if (this.flushIntervalSeconds) {
+                const interval = this.flushIntervalSeconds * 1000;
+                const tid = setTimeout(autoFlushCallback, interval);
+                // Let the event loop exit if this is the only active timer.
+                if (tid.unref) tid.unref();
+            }
+        };
+
+        autoFlushCallback();
+    }
+
+    /**
+     * Prepend the global key prefix and set the default host.
+     * @private
+     */
+    addPoint(Type, key, value, tags, timestampInMillis, options) {
+        this.aggregator.addPoint(Type, this.prefix + key, value, tags, this.host, timestampInMillis, options);
+    }
+
+    /**
+     * Record the current *value* of a metric. When flushed, a gauge reports only
+     * the most recent value, ignoring any other values recorded since the last
+     * flush.
+     *
+     * Optionally, specify a set of tags to associate with the metric. This should
+     * be continuously varying values such as total hard disk space, process uptime,
+     * total number of active users, or number of rows in a database table. The
+     * optional timestamp is in milliseconds since 1 Jan 1970 00:00:00 UTC,
+     * e.g. from `Date.now()`.
+     *
+     * @param {string} key
+     * @param {number} value
+     * @param {string[]} [tags]
+     * @param {number} [timestampInMillis]
+     *
+     * @example
+     * metrics.gauge('test.mem_free', 23);
+     */
+    gauge(key, value, tags, timestampInMillis) {
+        this.addPoint(Gauge, key, value, tags, timestampInMillis);
+    }
+
+    /**
+     * Increment the counter by the given *value* (or `1` by default). Optionally,
+     * specify a list of *tags* to associate with the metric. This is useful for
+     * counting things such as incrementing a counter each time a page is requested.
+     * The optional timestamp is in milliseconds since 1 Jan 1970 00:00:00 UTC,
+     * e.g. from `Date.now()`.
+     * @param {string} key
+     * @param {number} [value]
+     * @param {string[]} [tags]
+     * @param {number} [timestampInMillis]
+     *
+     * @example
+     * metrics.increment('test.requests_served');
+     * metrics.increment('test.awesomeness_factor', 10);
+     */
+    increment(key, value, tags, timestampInMillis) {
+        if (value === undefined || value === null) {
+            this.addPoint(Counter, key, 1, tags, timestampInMillis);
+        } else {
+            this.addPoint(Counter, key, value, tags, timestampInMillis);
+        }
+    }
+
+    /**
+     * Sample a histogram value. Histograms will produce metrics that
+     * describe the distribution of the recorded values, namely the minimum,
+     * maximum, average, median, count and the 75th, 85th, 95th and 99th percentiles.
+     * Optionally, specify a list of *tags* to associate with the metric.
+     * The optional timestamp is in milliseconds since 1 Jan 1970 00:00:00 UTC,
+     * e.g. from `Date.now()`.
+     * @param {string} key
+     * @param {number} value
+     * @param {string[]} [tags]
+     * @param {number} [timestampInMillis]
+     * @param {any} [options]
+     *
+     * @example
+     * metrics.histogram('test.service_time', 0.248);
+     *
+     * @example
+     * // Set custom options:
+     * metrics.histogram('test.service_time', 0.248, ['tag:value'], Date.now(), {
+     *     // Aggregates can include 'max', 'min', 'sum', 'avg', 'median', or 'count'.
+     *     aggregates: ['avg', 'count'],
+     *     // Percentiles can include any decimal between 0 and 1.
+     *     percentiles: [0.99]
+     * });
+     */
+    histogram(key, value, tags, timestampInMillis, options = {}) {
+        this.addPoint(Histogram, key, value, tags, timestampInMillis, {
+            ...this.histogramOptions,
+            ...options
+        });
+    }
+
+    /**
+     * Send a distribution value. Distributions are similar to histograms (they create
+     * several metrics for count, average, percentiles, etc.), but they are calculated
+     * server-side on Datadog’s systems. This is much higher-overhead than histograms,
+     * and the individual calculations made from it have to be configured on the
+     * Datadog website instead of in the options for this package.
+     *
+     * You should use this in environments where you have many instances of your
+     * application running in parallel, or instances constantly starting and stopping
+     * with different hostnames or identifiers and tagging each one separately is not
+     * feasible. AWS Lambda or serverless functions are a great example of this. In
+     * such environments, you also might want to use a distribution instead of
+     * `increment` or `gauge` (if you have two instances of your app sending those
+     * metrics at the same second, and they are not tagged differently or have
+     * different `host` names, one will overwrite the other — distributions will not).
+     * @param {string} key
+     * @param {number} value
+     * @param {string[]} [tags]
+     * @param {number} [timestampInMillis]
+     *
+     * @example
+     * metrics.distribution('test.service_time', 0.248);
+     */
+    distribution(key, value, tags, timestampInMillis) {
+        this.addPoint(Distribution, key, value, tags, timestampInMillis);
+    }
+
+    /**
+     * Calling `flush` sends any buffered metrics to Datadog. Unless you set
+     * `flushIntervalSeconds` to 0 it won't be necessary to call this function.
+     *
+     * It can be useful to trigger a manual flush by calling if you want to
+     * make sure pending metrics have been sent before you quit the application
+     * process, for example.
+     * @param {() => void} [onSuccess]
+     * @param {(error: Error) => void} [onError]
+     */
+    flush(onSuccess, onError) {
+        const series = this.aggregator.flush();
+        if (series.length > 0) {
+            logDebug('Flushing %d metrics to Datadog', series.length);
+            this.reporter.report(series, onSuccess, onError || this.onError);
+        } else {
+            logDebug('Nothing to flush');
+            if (typeof onSuccess === 'function') {
+                onSuccess();
+            }
+        }
+    }
 }
-
-/**
- * Prepend the global key prefix and set the default host.
- * @private
- */
-BufferedMetricsLogger.prototype.addPoint = function(Type, key, value, tags, timestampInMillis, options) {
-    this.aggregator.addPoint(Type, this.prefix + key, value, tags, this.host, timestampInMillis, options);
-};
-
-/**
- * Record the current *value* of a metric. When flushed, a gauge reports only
- * the most recent value, ignoring any other values recorded since the last
- * flush.
- *
- * Optionally, specify a set of tags to associate with the metric. This should
- * be continuously varying values such as total hard disk space, process uptime,
- * total number of active users, or number of rows in a database table. The
- * optional timestamp is in milliseconds since 1 Jan 1970 00:00:00 UTC,
- * e.g. from `Date.now()`.
- *
- * @param {string} key
- * @param {number} value
- * @param {string[]} [tags]
- * @param {number} [timestampInMillis]
- *
- * @example
- * metrics.gauge('test.mem_free', 23);
- */
-BufferedMetricsLogger.prototype.gauge = function(key, value, tags, timestampInMillis) {
-    this.addPoint(Gauge, key, value, tags, timestampInMillis);
-};
-
-/**
- * Increment the counter by the given *value* (or `1` by default). Optionally,
- * specify a list of *tags* to associate with the metric. This is useful for
- * counting things such as incrementing a counter each time a page is requested.
- * The optional timestamp is in milliseconds since 1 Jan 1970 00:00:00 UTC,
- * e.g. from `Date.now()`.
- * @param {string} key
- * @param {number} [value]
- * @param {string[]} [tags]
- * @param {number} [timestampInMillis]
- *
- * @example
- * metrics.increment('test.requests_served');
- * metrics.increment('test.awesomeness_factor', 10);
- */
-BufferedMetricsLogger.prototype.increment = function(key, value, tags, timestampInMillis) {
-    if (value === undefined || value === null) {
-        this.addPoint(Counter, key, 1, tags, timestampInMillis);
-    } else {
-        this.addPoint(Counter, key, value, tags, timestampInMillis);
-    }
-};
-
-/**
- * Sample a histogram value. Histograms will produce metrics that
- * describe the distribution of the recorded values, namely the minimum,
- * maximum, average, median, count and the 75th, 85th, 95th and 99th percentiles.
- * Optionally, specify a list of *tags* to associate with the metric.
- * The optional timestamp is in milliseconds since 1 Jan 1970 00:00:00 UTC,
- * e.g. from `Date.now()`.
- * @param {string} key
- * @param {number} value
- * @param {string[]} [tags]
- * @param {number} [timestampInMillis]
- * @param {any} [options]
- *
- * @example
- * metrics.histogram('test.service_time', 0.248);
- *
- * @example
- * // Set custom options:
- * metrics.histogram('test.service_time', 0.248, ['tag:value'], Date.now(), {
- *     // Aggregates can include 'max', 'min', 'sum', 'avg', 'median', or 'count'.
- *     aggregates: ['avg', 'count'],
- *     // Percentiles can include any decimal between 0 and 1.
- *     percentiles: [0.99]
- * });
- */
-BufferedMetricsLogger.prototype.histogram = function(key, value, tags, timestampInMillis, options = {}) {
-    this.addPoint(Histogram, key, value, tags, timestampInMillis, {
-        ...this.histogramOptions,
-        ...options
-    });
-};
-
-/**
- * Send a distribution value. Distributions are similar to histograms (they create
- * several metrics for count, average, percentiles, etc.), but they are calculated
- * server-side on Datadog’s systems. This is much higher-overhead than histograms,
- * and the individual calculations made from it have to be configured on the
- * Datadog website instead of in the options for this package.
- *
- * You should use this in environments where you have many instances of your
- * application running in parallel, or instances constantly starting and stopping
- * with different hostnames or identifiers and tagging each one separately is not
- * feasible. AWS Lambda or serverless functions are a great example of this. In
- * such environments, you also might want to use a distribution instead of
- * `increment` or `gauge` (if you have two instances of your app sending those
- * metrics at the same second, and they are not tagged differently or have
- * different `host` names, one will overwrite the other — distributions will not).
- * @param {string} key
- * @param {number} value
- * @param {string[]} [tags]
- * @param {number} [timestampInMillis]
- *
- * @example
- * metrics.distribution('test.service_time', 0.248);
- */
-BufferedMetricsLogger.prototype.distribution = function(key, value, tags, timestampInMillis) {
-    this.addPoint(Distribution, key, value, tags, timestampInMillis);
-};
-
-/**
- * Calling `flush` sends any buffered metrics to Datadog. Unless you set
- * `flushIntervalSeconds` to 0 it won't be necessary to call this function.
- *
- * It can be useful to trigger a manual flush by calling if you want to
- * make sure pending metrics have been sent before you quit the application
- * process, for example.
- * @param {() => void)} [onSuccess]
- * @param {(error: Error) => void} [onError]
- */
-BufferedMetricsLogger.prototype.flush = function(onSuccess, onError) {
-    const series = this.aggregator.flush();
-    if (series.length > 0) {
-        logDebug('Flushing %d metrics to Datadog', series.length);
-        this.reporter.report(series, onSuccess, onError || this.onError);
-    } else {
-        logDebug('Nothing to flush');
-        if (typeof onSuccess === 'function') {
-            onSuccess();
-        }
-    }
-};
 
 module.exports = {
     BufferedMetricsLogger

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -248,9 +248,9 @@ Distribution.prototype.serializeMetric = function(points, type, key) {
 };
 
 module.exports = {
-    Metric: Metric,
-    Gauge: Gauge,
-    Counter: Counter,
-    Histogram: Histogram,
-    Distribution: Distribution
+    Metric,
+    Gauge,
+    Counter,
+    Histogram,
+    Distribution
 };

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,251 +1,249 @@
 'use strict';
-const util = require('util');
-
-//
-// --- Metric (base class)
-//
 
 const DEFAULT_HISTOGRAM_AGGREGATES = ['max', 'min', 'sum', 'avg', 'count', 'median'];
 const DEFAULT_HISTOGRAM_PERCENTILES = [0.75, 0.85, 0.95, 0.99];
 
-function Metric(key, tags, host) {
-    this.key = key;
-    this.tags = tags || [];
-    this.host = host || '';
+
+/** Base class for all metric types. */
+class Metric {
+    /**
+     * Create a new metric object. Metric objects model each unique metric name
+     * and tag combination, keep track of each relevant data point, and
+     * calculate any derivative metrics (e.g. averages, percentiles, etc.).
+     * @param {string} key
+     * @param {string[]} [tags]
+     * @param {string} [host]
+     */
+    constructor(key, tags, host) {
+        this.key = key;
+        this.tags = tags || [];
+        this.host = host || '';
+    }
+
+    addPoint() {
+        return null;
+    }
+
+    flush() {
+        return null;
+    }
+
+    /** @protected */
+    posixTimestamp(timestampInMillis) {
+        // theoretically, 0 is a valid timestamp, albeit unlikely
+        const timestamp = timestampInMillis === undefined ? Date.now() : timestampInMillis;
+        return Math.round(timestamp / 1000);
+    }
+
+    /** @protected */
+    updateTimestamp(timestampInMillis) {
+        this.timestamp = this.posixTimestamp(timestampInMillis);
+    }
+
+    /** @protected */
+    serializeMetric(value, type, key) {
+        return {
+            metric: key || this.key,
+            points: [[this.timestamp, value]],
+            type: type,
+            host: this.host,
+            tags: this.tags.slice()
+        };
+    }
 }
 
-Metric.prototype.addPoint = function() {
-    return null;
-};
 
-Metric.prototype.flush = function() {
-    return null;
-};
+class Gauge extends Metric {
+    /**
+     * Record the current *value* of a metric. They most recent value in
+     * a given flush interval will be recorded. Optionally, specify a set of
+     * tags to associate with the metric. This should be used for sum values
+     * such as total hard disk space, process uptime, total number of active
+     * users, or number of rows in a database table.
+     * @param {string} key
+     * @param {string[]} [tags]
+     * @param {string} [host]
+     */
+    constructor(key, tags, host) {
+        super(key, tags, host);
+        this.value = 0;
+    }
 
-Metric.prototype.posixTimestamp = function(timestampInMillis) {
-    // theoretically, 0 is a valid timestamp, albeit unlikely
-    const timestamp = timestampInMillis === undefined ? Date.now() : timestampInMillis;
-    return Math.round(timestamp / 1000);
-};
+    addPoint(val, timestampInMillis) {
+        this.value = val;
+        this.updateTimestamp(timestampInMillis);
+    }
 
-Metric.prototype.updateTimestamp = function(timestampInMillis) {
-    this.timestamp = this.posixTimestamp(timestampInMillis);
-};
-
-Metric.prototype.serializeMetric = function(value, type, key) {
-    return {
-        metric: key || this.key,
-        points: [[this.timestamp, value]],
-        type: type,
-        host: this.host,
-        tags: this.tags.slice()
-    };
-};
-
-//
-// --- Gauge
-//
-
-//
-// GAUGE
-// -----
-// Record the current *value* of a metric. They most recent value in
-// a given flush interval will be recorded. Optionally, specify a set of
-// tags to associate with the metric. This should be used for sum values
-// such as total hard disk space, process uptime, total number of active
-// users, or number of rows in a database table.
-//
-
-function Gauge(key, tags, host) {
-    Metric.call(this, key, tags, host);
-    this.value = 0;
+    flush() {
+        return [this.serializeMetric(this.value, 'gauge')];
+    }
 }
 
-util.inherits(Gauge, Metric);
 
-Gauge.prototype.addPoint = function(val, timestampInMillis) {
-    this.value = val;
-    this.updateTimestamp(timestampInMillis);
-};
+class Counter extends Metric {
+    /**
+     * Increment the counter by the given *value*. Optionally, specify a list of
+     * *tags* to associate with the metric. This is useful for counting things
+     * such as incrementing a counter each time a page is requested.
+     * @param {string} key
+     * @param {string[]} [tags]
+     * @param {string} [host]
+     */
+    constructor(key, tags, host) {
+        super(key, tags, host);
+        this.value = 0;
+    }
 
-Gauge.prototype.flush = function() {
-    return [this.serializeMetric(this.value, 'gauge')];
-};
+    addPoint(val, timestampInMillis) {
+        this.value += val;
+        this.updateTimestamp(timestampInMillis);
+    }
 
-//
-// --- Counter
-//
-
-//
-// COUNTER
-// -------
-// Increment the counter by the given *value*. Optionally, specify a list of
-// *tags* to associate with the metric. This is useful for counting things
-// such as incrementing a counter each time a page is requested.
-//
-
-function Counter(key, tags, host) {
-    Metric.call(this, key, tags, host);
-    this.value = 0;
+    flush() {
+        return [this.serializeMetric(this.value, 'count')];
+    }
 }
 
-util.inherits(Counter, Metric);
 
-Counter.prototype.addPoint = function(val, timestampInMillis) {
-    this.value += val;
-    this.updateTimestamp(timestampInMillis);
-};
+class Histogram extends Metric {
+    /**
+     * Sample a histogram value. Histograms will produce metrics that
+     * describe the distribution of the recorded values, namely the minimum,
+     * maximum, average, count and the 75th, 85th, 95th and 99th percentiles.
+     * Optionally, specify a list of *tags* to associate with the metric.
+     * @param {string} key
+     * @param {string[]} [tags]
+     * @param {string} [host]
+     */
+    constructor(key, tags, host, options = {}) {
+        super(key, tags, host);
+        this.min = Infinity;
+        this.max = -Infinity;
+        this.sum = 0;
+        this.count = 0;
+        this.samples = [];
+        this.aggregates = options.aggregates || DEFAULT_HISTOGRAM_AGGREGATES;
+        this.percentiles = options.percentiles || DEFAULT_HISTOGRAM_PERCENTILES;
+    }
 
-Counter.prototype.flush = function() {
-    return [this.serializeMetric(this.value, 'count')];
-};
+    addPoint(val, timestampInMillis) {
+        this.updateTimestamp(timestampInMillis);
 
-//
-// --- Histogram
-//
+        this.min = Math.min(val, this.min);
+        this.max = Math.max(val, this.max);
+        this.sum += val;
+        this.count += 1;
 
-//
-// HISTOGRAM
-// ---------
-// Sample a histogram value. Histograms will produce metrics that
-// describe the distribution of the recorded values, namely the minimum,
-// maximum, average, count and the 75th, 85th, 95th and 99th percentiles.
-// Optionally, specify a list of *tags* to associate with the metric.
-//
+        // The number of samples recorded is unbounded at the moment.
+        // If this becomes a problem we might want to limit how many
+        // samples we keep.
+        this.samples.push(val);
+    }
 
-function Histogram(key, tags, host, options = {}) {
-    Metric.call(this, key, tags, host);
-    this.min = Infinity;
-    this.max = -Infinity;
-    this.sum = 0;
-    this.count = 0;
-    this.samples = [];
-    this.aggregates = options.aggregates || DEFAULT_HISTOGRAM_AGGREGATES;
-    this.percentiles = options.percentiles || DEFAULT_HISTOGRAM_PERCENTILES;
+    flush() {
+        let points = [];
+        if (this.aggregates.includes('min')) {
+            points.push(this.serializeMetric(this.min, 'gauge', this.key + '.min'));
+        }
+        if (this.aggregates.includes('max')) {
+            points.push(this.serializeMetric(this.max, 'gauge', this.key + '.max'));
+        }
+        if (this.aggregates.includes('sum')) {
+            points.push(this.serializeMetric(this.sum, 'gauge', this.key + '.sum'));
+        }
+        if (this.aggregates.includes('count')) {
+            points.push(this.serializeMetric(this.count, 'count', this.key + '.count'));
+        }
+        if (this.aggregates.includes('avg')) {
+            points.push(
+                this.serializeMetric(this.average(), 'gauge', this.key + '.avg')
+            );
+        }
+
+        // Careful, calling samples.sort() will sort alphabetically giving
+        // the wrong result. We must define our own compare function.
+        this.samples.sort((a, b) => a - b);
+
+        if (this.aggregates.includes('median')) {
+            points.push(
+                this.serializeMetric(this.median(this.samples), 'gauge', this.key + '.median')
+            );
+        }
+
+        const percentiles = this.percentiles.map((p) => {
+            const val = this.samples[Math.round(p * this.samples.length) - 1];
+            const suffix = '.' + Math.floor(p * 100) + 'percentile';
+            return this.serializeMetric(val, 'gauge', this.key + suffix);
+        });
+        return points.concat(percentiles);
+    }
+
+    average() {
+        if (this.count === 0) {
+            return 0;
+        } else {
+            return this.sum / this.count;
+        }
+    }
+
+    median(sortedSamples) {
+        if (this.count === 0) {
+            return 0;
+        } else if (this.count % 2 === 1) {
+            return sortedSamples[(this.count - 1) / 2];
+        } else {
+            return (sortedSamples[this.count / 2 - 1] + sortedSamples[this.count / 2]) / 2;
+        }
+    }
 }
 
-util.inherits(Histogram, Metric);
 
-Histogram.prototype.addPoint = function(val, timestampInMillis) {
-    this.updateTimestamp(timestampInMillis);
-
-    this.min = Math.min(val, this.min);
-    this.max = Math.max(val, this.max);
-    this.sum += val;
-    this.count += 1;
-
-    // The number of samples recorded is unbounded at the moment.
-    // If this becomes a problem we might want to limit how many
-    // samples we keep.
-    this.samples.push(val);
-};
-
-Histogram.prototype.flush = function () {
-    let points = [];
-    if (this.aggregates.includes('min')) {
-        points.push(this.serializeMetric(this.min, 'gauge', this.key + '.min'));
-    }
-    if (this.aggregates.includes('max')) {
-        points.push(this.serializeMetric(this.max, 'gauge', this.key + '.max'));
-    }
-    if (this.aggregates.includes('sum')) {
-        points.push(this.serializeMetric(this.sum, 'gauge', this.key + '.sum'));
-    }
-    if (this.aggregates.includes('count')) {
-        points.push(this.serializeMetric(this.count, 'count', this.key + '.count'));
-    }
-    if (this.aggregates.includes('avg')) {
-        points.push(
-            this.serializeMetric(this.average(), 'gauge', this.key + '.avg')
-        );
+class Distribution extends Metric {
+    /**
+     * Similar to a histogram, but sends every point to Datadog and does the
+     * calculations server-side.
+     *
+     * This is higher overhead than Counter or Histogram, but is particularly useful
+     * for serverless functions or other environments where many instances of your
+     * application may be running concurrently or constantly starting and stopping,
+     * and it does not make sense to tag each of them separately so metrics from
+     * each don't overwrite each other.
+     *
+     * See more documentation of use cases and how distribution work at:
+     * https://docs.datadoghq.com/metrics/types/?tab=distribution#metric-types
+     * @param {string} key
+     * @param {string[]} [tags]
+     * @param {string} [host]
+     */
+    constructor(key, tags, host) {
+        super(key, tags, host);
+        this.points = [];
     }
 
-    // Careful, calling samples.sort() will sort alphabetically giving
-    // the wrong result. We must define our own compare function.
-    this.samples.sort((a, b) => a - b);
-
-    if (this.aggregates.includes('median')) {
-        points.push(
-            this.serializeMetric(this.median(this.samples), 'gauge', this.key + '.median')
-        );
+    addPoint(val, timestampInMillis) {
+        const lastTimestamp = this.timestamp;
+        this.updateTimestamp(timestampInMillis);
+        if (lastTimestamp === this.timestamp) {
+            this.points[this.points.length - 1][1].push(val);
+        } else {
+            this.points.push([this.timestamp, [val]]);
+        }
     }
 
-    const percentiles = this.percentiles.map((p) => {
-        const val = this.samples[Math.round(p * this.samples.length) - 1];
-        const suffix = '.' + Math.floor(p * 100) + 'percentile';
-        return this.serializeMetric(val, 'gauge', this.key + suffix);
-    });
-    return points.concat(percentiles);
-};
-
-Histogram.prototype.average = function() {
-    if (this.count === 0) {
-        return 0;
-    } else {
-        return this.sum / this.count;
+    flush() {
+        return [this.serializeMetric(this.points, 'distribution')];
     }
-};
 
-Histogram.prototype.median = function(sortedSamples) {
-    if (this.count === 0) {
-        return 0;
-    } else if (this.count % 2 === 1) {
-        return sortedSamples[(this.count - 1) / 2];
-    } else {
-        return (sortedSamples[this.count / 2 - 1] + sortedSamples[this.count / 2]) / 2;
+    serializeMetric(points, type, key) {
+        return {
+            metric: key || this.key,
+            points: points || this.points,
+            type: type,
+            host: this.host,
+            tags: this.tags.slice()
+        };
     }
-};
-
-//
-// --- Distribution
-//
-
-//
-// DISTRIBUTION
-// ------------
-// Similar to a histogram, but sends every point to Datadog and does the
-// calculations server-side.
-//
-// This is higher overhead than Counter or Histogram, but is particularly useful
-// for serverless functions or other environments where many instances of your
-// application may be running concurrently or constantly starting and stopping,
-// and it does not make sense to tag each of them separately so metrics from
-// each don't overwrite each other.
-//
-// See more documentation of use cases and how distribution work at:
-// https://docs.datadoghq.com/metrics/types/?tab=distribution#metric-types
-//
-
-function Distribution(key, tags, host) {
-    Metric.call(this, key, tags, host);
-    this.points = [];
 }
-
-util.inherits(Distribution, Metric);
-
-Distribution.prototype.addPoint = function(val, timestampInMillis) {
-    const lastTimestamp = this.timestamp;
-    this.updateTimestamp(timestampInMillis);
-    if (lastTimestamp === this.timestamp) {
-        this.points[this.points.length - 1][1].push(val);
-    } else {
-        this.points.push([this.timestamp, [val]]);
-    }
-};
-
-Distribution.prototype.flush = function() {
-    return [this.serializeMetric(this.points, 'distribution')];
-};
-
-Distribution.prototype.serializeMetric = function(points, type, key) {
-    return {
-        metric: key || this.key,
-        points: points || this.points,
-        type: type,
-        host: this.host,
-        tags: this.tags.slice()
-    };
-};
 
 module.exports = {
     Metric,

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -2,10 +2,11 @@
 const datadogApiClient = require('@datadog/datadog-api-client');
 const { logDebug, logError } = require('./logging');
 
-//
-// NullReporter
-//
-
+/**
+ * A Reporter that throws away metrics instead of sending them to Datadog. This
+ * is useful for disabling metrics in your application and for tests.
+ * @constructor
+ */
 function NullReporter(_apiKey, _appKey) {
 
 }
@@ -17,12 +18,15 @@ NullReporter.prototype.report = function(series, onSuccess) {
     }
 };
 
-//
-// DataDogReporter
-//
-
 const datadogClients = new WeakMap();
 
+/**
+ * Reporter that sends metrics to Datadog's API.
+ * @constructor
+ * @param {string} [apiKey]
+ * @param {string} [appKey]
+ * @param {string} [apiHost]
+ */
 function DataDogReporter(apiKey, appKey, apiHost) {
     apiKey = apiKey || process.env.DATADOG_API_KEY;
     appKey = appKey || process.env.DATADOG_APP_KEY;
@@ -96,6 +100,6 @@ DataDogReporter.prototype.report = function(series, onSuccess, onError) {
 };
 
 module.exports = {
-    NullReporter: NullReporter,
-    DataDogReporter: DataDogReporter
+    NullReporter,
+    DataDogReporter
 };

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -5,99 +5,100 @@ const { logDebug, logError } = require('./logging');
 /**
  * A Reporter that throws away metrics instead of sending them to Datadog. This
  * is useful for disabling metrics in your application and for tests.
- * @constructor
  */
-function NullReporter(_apiKey, _appKey) {
-
-}
-
-NullReporter.prototype.report = function(series, onSuccess) {
-    // Do nothing.
-    if (typeof onSuccess === 'function') {
-        onSuccess();
+class NullReporter {
+    report(series, onSuccess) {
+        // Do nothing.
+        if (typeof onSuccess === 'function') {
+            onSuccess();
+        }
     }
-};
+}
 
 const datadogClients = new WeakMap();
 
 /**
- * Reporter that sends metrics to Datadog's API.
- * @constructor
- * @param {string} [apiKey]
- * @param {string} [appKey]
- * @param {string} [apiHost]
+ * Create a reporter that sends metrics to Datadog's API.
  */
-function DataDogReporter(apiKey, appKey, apiHost) {
-    apiKey = apiKey || process.env.DATADOG_API_KEY;
-    appKey = appKey || process.env.DATADOG_APP_KEY;
-    this.apiHost = apiHost || process.env.DATADOG_API_HOST;
+class DataDogReporter {
+    /**
+     * Create a reporter that sends metrics to Datadog's API.
+     * @param {string} [apiKey]
+     * @param {string} [appKey]
+     * @param {string} [apiHost]
+     */
+    constructor(apiKey, appKey, apiHost) {
+        apiKey = apiKey || process.env.DATADOG_API_KEY;
+        appKey = appKey || process.env.DATADOG_APP_KEY;
+        this.apiHost = apiHost || process.env.DATADOG_API_HOST;
 
-    if (!apiKey) {
-        throw new Error('DATADOG_API_KEY environment variable not set');
-    }
-
-    const configuration = datadogApiClient.client.createConfiguration({
-        authMethods: {
-            apiKeyAuth: apiKey,
-            appKeyAuth: appKey
+        if (!apiKey) {
+            throw new Error('DATADOG_API_KEY environment variable not set');
         }
-    });
-    if (this.apiHost) {
-        // Strip leading `app.` from the site in case someone copy/pasted the
-        // URL from their web browser. More details on correct configuration:
-        // https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
-        this.apiHost = apiHost.replace(/^app\./i, '');
-        datadogApiClient.client.setServerVariables(configuration, {
-            site: this.apiHost
-        });
-    }
-    datadogClients.set(this, new datadogApiClient.v1.MetricsApi(configuration));
-}
 
-DataDogReporter.prototype.report = function(series, onSuccess, onError) {
-    logDebug('Calling report with %j', series);
-
-    // Distributions must be submitted via a different method than other
-    // metrics, so split them up.
-    const metrics = [];
-    const distributions = [];
-    for (const metric of series) {
-        if (metric.type === 'distribution') {
-            distributions.push(metric);
-        } else {
-            metrics.push(metric);
-        }
-    }
-
-    const metricsApi = datadogClients.get(this);
-
-    let submissions = [];
-    if (metrics.length) {
-        submissions.push(metricsApi.submitMetrics({
-            body: { series: metrics }
-        }));
-    }
-    if (distributions.length) {
-        submissions.push(metricsApi.submitDistributionPoints({
-            body: { series: distributions }
-        }));
-    }
-
-    Promise.all(submissions)
-        .then(() => {
-            logDebug('sent metrics successfully');
-            if (typeof onSuccess === 'function') {
-                onSuccess();
+        const configuration = datadogApiClient.client.createConfiguration({
+            authMethods: {
+                apiKeyAuth: apiKey,
+                appKeyAuth: appKey
             }
-        })
-        .catch((error) => {
-            if (typeof onError === 'function') {
-                onError(error);
+        });
+        if (this.apiHost) {
+            // Strip leading `app.` from the site in case someone copy/pasted the
+            // URL from their web browser. More details on correct configuration:
+            // https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
+            this.apiHost = apiHost.replace(/^app\./i, '');
+            datadogApiClient.client.setServerVariables(configuration, {
+                site: this.apiHost
+            });
+        }
+        datadogClients.set(this, new datadogApiClient.v1.MetricsApi(configuration));
+    }
+
+    report(series, onSuccess, onError) {
+        logDebug('Calling report with %j', series);
+
+        // Distributions must be submitted via a different method than other
+        // metrics, so split them up.
+        const metrics = [];
+        const distributions = [];
+        for (const metric of series) {
+            if (metric.type === 'distribution') {
+                distributions.push(metric);
             } else {
-                logError('failed to send metrics (err=%s)', error);
+                metrics.push(metric);
             }
-        });
-};
+        }
+
+        const metricsApi = datadogClients.get(this);
+
+        let submissions = [];
+        if (metrics.length) {
+            submissions.push(metricsApi.submitMetrics({
+                body: { series: metrics }
+            }));
+        }
+        if (distributions.length) {
+            submissions.push(metricsApi.submitDistributionPoints({
+                body: { series: distributions }
+            }));
+        }
+
+        Promise.all(submissions)
+            .then(() => {
+                logDebug('sent metrics successfully');
+                if (typeof onSuccess === 'function') {
+                    onSuccess();
+                }
+            })
+            .catch((error) => {
+                if (typeof onError === 'function') {
+                    onError(error);
+                } else {
+                    logError('failed to send metrics (err=%s)', error);
+                }
+            });
+    }
+}
 
 module.exports = {
     NullReporter,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/dbader/node-datadog-metrics/issues"
   },
   "scripts": {
-    "prepare": "npm run clean && npm run build-types",
+    "prepack": "npm run clean && npm run build-types",
     "test": "mocha --reporter spec",
     "check-codestyle": "npx eslint .",
     "check-text": "test/lint_text.sh",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.10.1",
   "description": "Buffered metrics reporting via the Datadog HTTP API",
   "main": "index.js",
+  "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git@github.com:dbader/node-datadog-metrics.git"
@@ -11,9 +12,12 @@
     "url": "https://github.com/dbader/node-datadog-metrics/issues"
   },
   "scripts": {
+    "prepare": "npm run clean && npm run build-types",
     "test": "mocha --reporter spec",
     "check-codestyle": "npx eslint .",
-    "check-text": "test/lint_text.sh"
+    "check-text": "test/lint_text.sh",
+    "build-types": "tsc --build",
+    "clean": "tsc --build --clean"
   },
   "keywords": [
     "datadog",
@@ -27,7 +31,8 @@
     "chai-string": "1.5.0",
     "eslint": "^8.24.0",
     "mocha": "9.2.2",
-    "nock": "^13.2.9"
+    "nock": "^13.2.9",
+    "typescript": "^4.8.4"
   },
   "dependencies": {
     "@datadog/datadog-api-client": "^1.3.0",
@@ -35,5 +40,12 @@
   },
   "engines": {
     "node": ">=12.0.0"
-  }
+  },
+  "files": [
+    "README.md",
+    "LICENSE",
+    "index.js",
+    "lib/**",
+    "dist/**"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,9 +8,7 @@
         "allowSyntheticDefaultImports": true,
         "moduleResolution": "node",
         "allowJs": true,
-        // TODO: Consider turning this type-checking in PRs. Needs class syntax
-        // to work, though
-        // "checkJs": true,
+        "checkJs": true,
         "composite": true,
 
         "outDir": "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "lib": ["es2019"],
+        "target": "es2019",
+
+        "module": "commonjs",
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "moduleResolution": "node",
+        "allowJs": true,
+        // TODO: Consider turning this type-checking in PRs. Needs class syntax
+        // to work, though
+        // "checkJs": true,
+        "composite": true,
+
+        "outDir": "dist",
+        "declarationMap": true,
+        "declaration": true,
+        "emitDeclarationOnly": true
+    },
+    "include": ["./index.js", "./lib/**/*"]
+}


### PR DESCRIPTION
This converts most of the function/class comments in the code to JSDoc-style comments (adding some more detailed descriptions/types along the way) and uses TypeScript to build type definition files from the comments. This allows us to publish types directly from this package instead of making TypeScript users install `@types/datadog-metrics`, which is maintained separately, by hand, and isn’t always be up-to-date.

It also converts old-style classes to the newer, ES6+ class syntax. The TypeScript compiler generates clearer and less redundant type definitions when classes are used, so this actually has a meaningful impact beyond just code style.

When building types, the TypeScript compiler can perform limited validation of the actual JavaScipt code (making sure it plausibly matches the types in the comments, and where types are specified, making sure the code matches what the types say can be done). I’ve turned that on and added a CI step to generate types, so we should see errors if the doc comments change in an incorrect way, or if a function signature changes without also updating the doc comments describing the types.

Finally, I’ve added an NPM lifecycle script to automatically build types when publishing.

You can manually build types by running `npm run build-types` or clear out any generated code types by running `npm run clean`. The type definitions are build in the `dist` directory.

Note this does *not* do type checking on the test files — that would be a good idea, but would require a bunch more changes, and this PR is already too big (e.g. the `should` assertions don’t work, you need to use `expect` instead).

Fixes #83, fixes #86.