### PR TITLE
Allow to use a fully custom datadog ingestion endpoint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,7 @@
         "max-params": ["error", 10],
         "max-depth": ["error", 5],
         "max-statements": ["error", 25],
-        "max-len": ["error", 110],
+        "max-len": ["error", { "code": 110, "ignoreUrls": true }],
         "no-var": ["error"],
         // Allow unused vars if prefixed with "_"
         "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],

--- a/README.md
+++ b/README.md
@@ -101,6 +101,22 @@ var metricsLogger = new metrics.BufferedMetricsLogger({
 metricsLogger.gauge('mygauge', 42);
 ```
 
+
+#### Use case #4: Send datadog series to... not datadog.
+
+If you want to send datadog metrics to an endpoint that accepts the datadog format but, potentially, is not datadog.
+
+```js
+var metrics = require('datadog-metrics');
+var metricsLogger = new metrics.BufferedMetricsLogger({
+    customServerURL: 'https://datadog.compatible.service.io/datadog/endpoint',
+    apiKey: 'DUMMYKEY',
+    host: 'myhost',
+    prefix: 'myapp.',
+});
+metricsLogger.gauge('mygauge', 42);
+```
+
 ## API
 
 ### Initialization
@@ -122,6 +138,8 @@ Where `options` is an object and can contain the following:
     * Defaults to `datadoghq.com`.
     * See more details on setting your site at:
         https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
+* `customServerURL`: Sends metrics to a custom server that supports Datadog metrics
+    format but is not datadog. This feature is incompatible with apiHost. (optional)
 * `apiKey`: Sets the Datadog API key. (optional)
     * It's usually best to keep this in an environment variable.
       Datadog-metrics looks for the API key in `DATADOG_API_KEY` by default.

--- a/README.md
+++ b/README.md
@@ -138,8 +138,14 @@ Where `options` is an object and can contain the following:
     * Defaults to `datadoghq.com`.
     * See more details on setting your site at:
         https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
+    * Do not use in conjunction with `customServerURL`
 * `customServerURL`: Sends metrics to a custom server that supports Datadog metrics
-    format but is not datadog. This feature is incompatible with apiHost. (optional)
+    format but is not datadog. If used, the value of `customServerURL` takes precedence
+    to the value of `apiHost`. (optional)
+    If data is to be sent to Datadog, consider using `apiHost`. If not, this parameter will allow to fully
+    configure a different server to ship metrics to. Giving full control on the protocol, url and path to use.
+    e.g.: `http://non-secure-metrics-insert.local_network` or `https://custom-metrics-insert.com/datadog/metrics`
+    * Value for this parameter can be passed via environment variable with the key `DATADOG_CUSTOM_URL`.
 * `apiKey`: Sets the Datadog API key. (optional)
     * It's usually best to keep this in an environment variable.
       Datadog-metrics looks for the API key in `DATADOG_API_KEY` by default.

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -37,6 +37,8 @@ const Distribution = require('./metrics').Distribution;
  * @property {string} [apiHost] Sets the Datadog "site", or server where metrics
  *           are sent. For details and options, see:
  *           https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
+ * @property {string} [customServerURL] Sends metrics to a custom server that supports Datadog metrics format
+ *           but is not datadog. This feature is incompatible with apiHost
  * @property {number} [flushIntervalSeconds] How often to send metrics to
  *           Datadog (in seconds).
  * @property {string[]} [defaultTags] Default tags used for all metrics.
@@ -77,7 +79,11 @@ class BufferedMetricsLogger {
         /** @private */
         this.aggregator = opts.aggregator || new Aggregator(opts.defaultTags);
         /** @private */
-        this.reporter = opts.reporter || new DataDogReporter(opts.apiKey, opts.appKey, opts.apiHost);
+        this.reporter = opts.reporter || new DataDogReporter(
+            opts.apiKey,
+            opts.appKey,
+            opts.apiHost,
+            opts.customServerURL);
         /** @private */
         this.host = opts.host;
         /** @private */

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -1,8 +1,6 @@
 'use strict';
 const datadogApiClient = require('@datadog/datadog-api-client');
 const { logDebug, logError } = require('./logging');
-// eslint-disable-next-line max-len
-const { BaseServerConfiguration } = require('@datadog/datadog-api-client/dist/packages/datadog-api-client-common');
 
 /**
  * A Reporter that throws away metrics instead of sending them to Datadog. This
@@ -34,17 +32,22 @@ class DataDogReporter {
         apiKey = apiKey || process.env.DATADOG_API_KEY;
         appKey = appKey || process.env.DATADOG_APP_KEY;
         this.apiHost = apiHost || process.env.DATADOG_API_HOST;
-        this.customServerURL = customServerURL || process.env.CUSTOM_SERVER_URL;
+        this.customServerURL = customServerURL || process.env.DATADOG_CUSTOM_URL;
 
         if (!apiKey) {
             throw new Error('DATADOG_API_KEY environment variable not set');
         }
 
+        if (apiHost && customServerURL) {
+            console.warn('WARN: datadog-metrics configured to use both "apiHost" ' +
+                'and "customServerURL". This is not a supported configuration. ' +
+                'The value of "apiHost" value is going to be ignored.');
+        }
+
         // If baseServer is undefined, the Datadog SDK will use the hardcoded Datadog servers
-        // eslint-disable-next-line max-len
         // See: https://github.com/DataDog/datadog-api-client-typescript/blob/v1.6.0/packages/datadog-api-client-common/servers.ts#L58
         const baseServer = this.customServerURL ?
-            new BaseServerConfiguration(customServerURL, {}) : undefined;
+            new datadogApiClient.client.BaseServerConfiguration(customServerURL, {}) : undefined;
 
         const configurationOpts = {
             baseServer: baseServer,

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -1,6 +1,8 @@
 'use strict';
 const datadogApiClient = require('@datadog/datadog-api-client');
 const { logDebug, logError } = require('./logging');
+// eslint-disable-next-line max-len
+const { BaseServerConfiguration } = require('@datadog/datadog-api-client/dist/packages/datadog-api-client-common');
 
 /**
  * A Reporter that throws away metrics instead of sending them to Datadog. This
@@ -26,22 +28,32 @@ class DataDogReporter {
      * @param {string} [apiKey]
      * @param {string} [appKey]
      * @param {string} [apiHost]
+     * @param {string} [customServerURL]
      */
-    constructor(apiKey, appKey, apiHost) {
+    constructor(apiKey, appKey, apiHost, customServerURL) {
         apiKey = apiKey || process.env.DATADOG_API_KEY;
         appKey = appKey || process.env.DATADOG_APP_KEY;
         this.apiHost = apiHost || process.env.DATADOG_API_HOST;
+        this.customServerURL = customServerURL || process.env.CUSTOM_SERVER_URL;
 
         if (!apiKey) {
             throw new Error('DATADOG_API_KEY environment variable not set');
         }
 
-        const configuration = datadogApiClient.client.createConfiguration({
+        // If baseServer is undefined, the Datadog SDK will use the hardcoded Datadog servers
+        // eslint-disable-next-line max-len
+        // See: https://github.com/DataDog/datadog-api-client-typescript/blob/v1.6.0/packages/datadog-api-client-common/servers.ts#L58
+        const baseServer = this.customServerURL ?
+            new BaseServerConfiguration(customServerURL, {}) : undefined;
+
+        const configurationOpts = {
+            baseServer: baseServer,
             authMethods: {
                 apiKeyAuth: apiKey,
                 appKeyAuth: appKey
             }
-        });
+        };
+        const configuration = datadogApiClient.client.createConfiguration(configurationOpts);
         if (this.apiHost) {
             // Strip leading `app.` from the site in case someone copy/pasted the
             // URL from their web browser. More details on correct configuration:

--- a/test/loggers_tests.js
+++ b/test/loggers_tests.js
@@ -183,6 +183,23 @@ describe('BufferedMetricsLogger', function() {
         l.reporter.should.have.property('apiHost', 'datadoghq.eu');
     });
 
+    it('should send the request to the customServerURL', function(done) {
+        nock('https://my.compatible.datadog.ingestor/datadog')
+            .post('/api/v1/series')
+            .reply(202, { errors: [] });
+
+        const logger = new BufferedMetricsLogger({
+            apiKey: 'abc',
+            customServerURL: 'https://my.compatible.datadog.ingestor/datadog'
+        });
+        logger.gauge('test.gauge', 23);
+
+        logger.flush(
+            () => done(),
+            (error) => done(error || new Error('Error handler called with no error object.'))
+        );
+    });
+
     it('should call the flush success handler after flushing', function(done) {
         nock('https://api.datadoghq.com')
             .post('/api/v1/series')


### PR DESCRIPTION
Under some circumstances it is useful to have metrics shipped elsewhere than datadog endpoints. This is also supported in other Datadog applications (e.g. [Datadog Agent](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml#L32)).

This PR adds a new configuration parameter which will allow to set a fully custom server url. This will allow to ship the metrics to that server, as opposed to the hardcoded values defined in the `@datadog/datadog-api-client` library.