### PR TITLE
chore: update api usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,13 @@ npm test
 
 * (In Development)
 
+    **New Features:**
+
     * Nothing yet!
+
+    **Fixes & Maintenance:**
+
+    * Resolve a deprecation warning from the underlying datadog-api-client library. This also updates the minimum required version of that library. (Thanks to @acatalucci-synth & @fcsonline in #112.)
 
     [View diff](https://github.com/dbader/node-datadog-metrics/compare/v0.10.2...main)
 

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -47,7 +47,7 @@ class DatadogReporter {
             // URL from their web browser. More details on correct configuration:
             // https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
             this.site = this.site.replace(/^app\./i, '');
-            datadogApiClient.client.setServerVariables(configuration, {
+            configuration.setServerVariables(configuration, {
                 site: this.site
             });
         }

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -47,7 +47,7 @@ class DatadogReporter {
             // URL from their web browser. More details on correct configuration:
             // https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
             this.site = this.site.replace(/^app\./i, '');
-            configuration.setServerVariables(configuration, {
+            configuration.setServerVariables({
                 site: this.site
             });
         }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "^1.3.0",
+    "@datadog/datadog-api-client": "^1.16.0",
     "debug": "^4.1.0"
   },
   "engines": {


### PR DESCRIPTION
This is a trivial change following an api deprecation to @datadog/datadog-api-client

Every time I've been using this library i get a
```
setServerVariables is deprecated, please use Configuration.setServerVariables instead.
```
on startup.

After this change, the deprecation warning has gone away