### PR TITLE
Avoid setServerVariables deprecation warning

### DIFF
--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -47,9 +47,7 @@ class DatadogReporter {
             // URL from their web browser. More details on correct configuration:
             // https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
             this.site = this.site.replace(/^app\./i, '');
-            datadogApiClient.client.setServerVariables(configuration, {
-                site: this.site
-            });
+            configuration.setServerVariables({ site: this.site });
         }
         datadogClients.set(this, new datadogApiClient.v1.MetricsApi(configuration));
     }


### PR DESCRIPTION
Avoid a deprecation warning:

```
setServerVariables is deprecated, please use Configuration.setServerVariables instead.
````