### PR TITLE
fix: Wrong terminology in types and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ npm test
 
 * (In Development)
 
-    * Nothing yet!
+    * Fix types and documentation for the `aggregates` option for histograms and the `histogram.aggregates` option for the library as a whole. It was previously listed as `aggregations`, which was incorrect. (Thanks to @Calyhre in #117.)
 
     [View diff](https://github.com/dbader/node-datadog-metrics/compare/v0.11.1...main)
 

--- a/README.md
+++ b/README.md
@@ -378,17 +378,17 @@ npm test
         const metrics = require('datadog-metrics');
         metrics.init({
             histogram: {
-                aggregations: ['sum', 'avg'],
+                aggregates: ['sum', 'avg'],
                 percentiles: [0.99]
             }
         });
 
         // Acts as if the options had been set to:
-        // { aggregations: ['sum', 'avg'], percentiles: [0.99] }
+        // { aggregates: ['sum', 'avg'], percentiles: [0.99] }
         metrics.histogram('my.metric.name', 3.8);
 
         // Acts as if the options had been set to:
-        // { aggregations: ['sum', 'avg'], percentiles: [0.5, 0.95] }
+        // { aggregates: ['sum', 'avg'], percentiles: [0.5, 0.95] }
         metrics.histogram('my.metric.name', 3.8, [], Date.now(), {
             percentiles: [0.5, 0.95]
         });
@@ -427,7 +427,7 @@ npm test
         const metrics = require('datadog-metrics');
         metrics.histogram('my.metric.name', 3.8, [], Date.now(), {
             // Aggregates can include 'max', 'min', 'sum', 'avg', or 'count'.
-            aggregations: ['max', 'min', 'sum', 'avg', 'count'],
+            aggregates: ['max', 'min', 'sum', 'avg', 'count'],
             // Percentiles can include any decimal between 0 and 1.
             percentiles: [0.75, 0.85, 0.95, 0.99]
         });

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -42,7 +42,7 @@ const Distribution = require('./metrics').Distribution;
  *           Datadog (in seconds).
  * @property {string[]} [defaultTags] Default tags used for all metrics.
  * @property {object} [histogram] Default options for histograms.
- * @property {string[]} [histogram.aggregations] A list of aggregations to
+ * @property {string[]} [histogram.aggregates] A list of aggregations to
  *           to create metrics for on histograms. Values can be any of:
  *           'max', 'min', 'sum', 'avg', 'count', or 'median'.
  * @property {number[]} [histogram.percentiles] A list of percentiles to create

--- a/test/loggers_tests.js
+++ b/test/loggers_tests.js
@@ -120,7 +120,8 @@ describe('BufferedMetricsLogger', function() {
         const l = new BufferedMetricsLogger({
             reporter: new reporters.NullReporter(),
             histogram: {
-                percentiles: [0.5]
+                percentiles: [0.5],
+                aggregates: ['sum']
             }
         });
         l.histogram('test.histogram', 23);
@@ -131,6 +132,12 @@ describe('BufferedMetricsLogger', function() {
         percentiles.should.have.nested.property(
             '[0].metric',
             'test.histogram.50percentile'
+        );
+        const aggregates = f.filter(x => /\.histogram\.[a-z]/.test(x.metric));
+        aggregates.should.have.length(1);
+        aggregates.should.have.nested.property(
+            '[0].metric',
+            'test.histogram.sum'
         );
     });
 


### PR DESCRIPTION
Hello 👋 small but important fix here.

[`aggregates`](https://github.com/dbader/node-datadog-metrics/blob/a8beb15eb1d31bd30898522101b5627c41b35ef4/lib/metrics.js#L125) is the real option used, but documentation and typing are suggesting it should be `aggregations`