### PR TITLE
Export a *type* for BufferedMetricsLogger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,7 @@ jobs:
       - name: Build Types
         run: |
           npm run build-types
+
+      - name: Check Types
+        run: |
+          npm run check-types

--- a/README.md
+++ b/README.md
@@ -307,7 +307,9 @@ npm test
 
 * (In Development)
 
-    * Nothing yet!
+    **Bug Fixes:**
+
+    * Typings: Ensure `BufferedMetricsLogger` is seen as an actual class & type when importing in TypeScript. (#120)
 
     [View diff](https://github.com/dbader/node-datadog-metrics/compare/v0.11.2...main)
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 'use strict';
-const loggers = require('./lib/loggers');
+const { BufferedMetricsLogger } = require('./lib/loggers');
 const reporters = require('./lib/reporters');
+
+/** @typedef {import("./lib/loggers").BufferedMetricsLoggerOptions} BufferedMetricsLoggerOptions */
 
 let sharedLogger = null;
 
@@ -10,14 +12,14 @@ let sharedLogger = null;
  * Any settings used here will apply to the top-level metrics functions (e.g.
  * `increment()`, `gauge()`). If you need multiple separate configurations, use
  * the `BufferedMetricsLogger` class.
- * @param {loggers.BufferedMetricsLoggerOptions} [opts]
+ * @param {BufferedMetricsLoggerOptions} [opts]
  */
 function init(opts) {
     opts = opts || {};
     if (!opts.flushIntervalSeconds && opts.flushIntervalSeconds !== 0) {
         opts.flushIntervalSeconds = 15;
     }
-    sharedLogger = new loggers.BufferedMetricsLogger(opts);
+    sharedLogger = new BufferedMetricsLogger(opts);
 }
 
 /**
@@ -41,13 +43,13 @@ function callOnSharedLogger(func) {
 
 module.exports = {
     init,
-    flush: callOnSharedLogger(loggers.BufferedMetricsLogger.prototype.flush),
-    gauge: callOnSharedLogger(loggers.BufferedMetricsLogger.prototype.gauge),
-    increment: callOnSharedLogger(loggers.BufferedMetricsLogger.prototype.increment),
-    histogram: callOnSharedLogger(loggers.BufferedMetricsLogger.prototype.histogram),
-    distribution: callOnSharedLogger(loggers.BufferedMetricsLogger.prototype.distribution),
+    flush: callOnSharedLogger(BufferedMetricsLogger.prototype.flush),
+    gauge: callOnSharedLogger(BufferedMetricsLogger.prototype.gauge),
+    increment: callOnSharedLogger(BufferedMetricsLogger.prototype.increment),
+    histogram: callOnSharedLogger(BufferedMetricsLogger.prototype.histogram),
+    distribution: callOnSharedLogger(BufferedMetricsLogger.prototype.distribution),
 
-    BufferedMetricsLogger: loggers.BufferedMetricsLogger,
+    BufferedMetricsLogger,
 
     reporters
 };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "author": "Daniel Bader <mail@dbader.org> (http://dbader.org/)",
   "license": "MIT",
   "devDependencies": {
+    "@types/node": "^12.20.55",
     "chai": "4.3.6",
     "chai-string": "1.5.0",
     "eslint": "^8.24.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check-codestyle": "npx eslint .",
     "check-text": "test/lint_text.sh",
     "build-types": "tsc --build",
+    "check-types": "tsc --noEmit --strict test/types_check.ts",
     "clean": "tsc --build --clean"
   },
   "keywords": [

--- a/test/types_check.ts
+++ b/test/types_check.ts
@@ -1,0 +1,9 @@
+// This file is used to check the typings! It is not mean to be executed.
+import { BufferedMetricsLogger } from '..';
+import type { BufferedMetricsLoggerOptions } from '..';
+
+function useLogger(logger: BufferedMetricsLogger) {
+  logger.gauge('key', 0);
+}
+
+useLogger(new BufferedMetricsLogger());

--- a/test/types_check.ts
+++ b/test/types_check.ts
@@ -1,9 +1,53 @@
 // This file is used to check the typings! It is not mean to be executed.
-import { BufferedMetricsLogger } from '..';
+import {
+    BufferedMetricsLogger,
+    reporters,
+    init,
+    flush,
+    gauge,
+    increment,
+    histogram,
+    distribution
+} from '..';
 import type { BufferedMetricsLoggerOptions } from '..';
 
 function useLogger(logger: BufferedMetricsLogger) {
-  logger.gauge('key', 0);
+    logger.gauge('gauge.key', 0);
+    logger.increment('increment.key');
+    logger.histogram('histogram.key', 11);
+    logger.distribution('distribution.key', 11);
+    logger.flush();
 }
 
 useLogger(new BufferedMetricsLogger());
+
+init({
+    apiKey: 'abc123',
+    appKey: 'xyz456',
+    apiHost: 'datadoghq.eu',
+    site: 'datadoghq.eu',
+    prefix: 'key.prefix',
+    host: 'some-name-for-this-machine',
+    flushIntervalSeconds: 5,
+    defaultTags: ['tag'],
+    histogram: {
+        aggregates: ['sum', 'avg'],
+        percentiles: [0.99]
+    },
+    onError (error) { console.error(error); },
+    aggregator: {
+        addPoint (type: Function, key: string, value: number, tags: string[], host: string, timestampInMillis: number, options: any) {
+            console.log("Adding a point!");
+        },
+        flush () {
+            return [];
+        }
+    },
+    reporter: new reporters.NullReporter()
+});
+
+gauge('gauge.key', 0);
+increment('increment.key');
+histogram('histogram.key', 11);
+distribution('distribution.key', 11);
+flush();


### PR DESCRIPTION
Even though we started generating TypeScript types from the JSDoc a while back, it turns out `BufferedMetricsLogger` was getting exported as a value and not a type, which technically works in TS, but is definitely not what you want. This changes up our syntax a bit to get the compiler to do the right thing, and adds a basic test of the types to make sure we don't regress.

Fixes #119.

Worth thinking about briefly before landing: are there other types we should be taking more care to export here?