### PR TITLE
Expand CI test matrix, add dependabot for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,17 @@ on:
 
 name: Continuous Integration
 
+env:
+  default_node_version: 22
+
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [12, 14, 16, 18]
+        # Test supported release Node.js versions (even numbers) plus current
+        # development version.
+        node_version: [12, 14, 16, 18, 20, 22, 23]
 
     steps:
       - uses: actions/checkout@v3
@@ -38,7 +43,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: ${{ env.default_node_version }}
           cache: 'npm'
           cache-dependency-path: '**/package.json'
 
@@ -61,7 +66,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: ${{ env.default_node_version }}
           cache: 'npm'
           cache-dependency-path: '**/package.json'
 


### PR DESCRIPTION
Node.js has moved forward by several major versions since our CI configuration was last updated, and this updates our CI test matrix to cover them. I've also added Dependabot for updating CI workflows, but not JS dependencies (we only want security updates there).