### PR TITLE
Use promises instead of callbacks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,6 +44,9 @@
             "files": ["test/**/*.js"],
             "env": {
                 "mocha": true
+            },
+            "rules": {
+                "max-statements": ["off"]
             }
         }
       ]

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -1,5 +1,5 @@
 'use strict';
-const { logDebug, logDeprecation } = require('./logging');
+const { logDebug, logDeprecation, logError } = require('./logging');
 const Aggregator = require('./aggregators').Aggregator;
 const { DatadogReporter } = require('./reporters');
 const Gauge = require('./metrics').Gauge;
@@ -24,8 +24,17 @@ const Distribution = require('./metrics').Distribution;
  */
 
 /**
- * @typedef {object} ReporterType
+ * @typedef {object} CallbackReporterType
  * @property {(series: any[], onSuccess?: Function, onError?: Function) => void} report
+ */
+
+/**
+ * @typedef {object} PromiseReporterType
+ * @property {(series: any[]) => Promise} report
+ */
+
+/**
+ * @typedef {PromiseReporterType|CallbackReporterType} ReporterType
  */
 
 /**
@@ -88,7 +97,7 @@ class BufferedMetricsLogger {
 
         /** @private */
         this.aggregator = opts.aggregator || new Aggregator(opts.defaultTags);
-        /** @private */
+        /** @private @type {ReporterType} */
         this.reporter = opts.reporter || new DatadogReporter(opts.apiKey, opts.appKey, opts.site);
         /** @private */
         this.host = opts.host;
@@ -245,20 +254,60 @@ class BufferedMetricsLogger {
      * It can be useful to trigger a manual flush by calling if you want to
      * make sure pending metrics have been sent before you quit the application
      * process, for example.
-     * @param {() => void} [onSuccess]
-     * @param {(error: Error) => void} [onError]
+     * @param {() => void} [onSuccess] This argument is deprecated and will soon
+     *        be removed! Please use the returned promise instead.
+     * @param {(error: Error) => void} [onError] This argument is deprecated and
+     *        will soon be removed! Please use the returned promise instead.
+     * @returns {Promise}
      */
     flush(onSuccess, onError) {
-        const series = this.aggregator.flush();
-        if (series.length > 0) {
-            logDebug('Flushing %d metrics to Datadog', series.length);
-            this.reporter.report(series, onSuccess, onError || this.onError);
-        } else {
-            logDebug('Nothing to flush');
-            if (typeof onSuccess === 'function') {
-                onSuccess();
+        const result = new Promise((resolve, reject) => {
+            const series = this.aggregator.flush();
+            if (series.length > 0) {
+                logDebug('Flushing %d metrics to Datadog', series.length);
+
+                if (this.reporter.report.length > 1) {
+                    logDeprecation(
+                        'Callback arguments on the `report()` method of a ' +
+                        'reporter are deprecated and will stop working in a ' +
+                        'future release. Please update your reporter to ' +
+                        'return a promise instead.'
+                    );
+                    this.reporter.report(series, resolve, reject);
+                } else {
+                    // @ts-expect-error TS can't figure out we have a promise here.
+                    this.reporter.report(series).then(resolve, reject);
+                }
+            } else {
+                logDebug('Nothing to flush');
+                resolve();
             }
+        });
+
+        if (onSuccess || onError) {
+            logDeprecation(
+                'The `onSuccess` and `onError` callback arguments for ' +
+                'BufferedMetricsLogger.flush() are deprecated and will be ' +
+                'removed in a future release. Please use the promise object that ' +
+                '`flush()` returns instead.'
+            );
+            result.then(
+                typeof onSuccess === 'function' ? onSuccess : () => null,
+                typeof onError === 'function' ? onError : () => null
+            );
         }
+
+        // Notify global handler *and* ensure a simple call to `logger.flush()`
+        // without error handling doesn't throw an unhandled rejection error.
+        result.catch((error) => {
+            if (this.onError) {
+                this.onError(error);
+            } else {
+                logError('failed to send metrics (err=%s)', error);
+            }
+        });
+
+        return result;
     }
 }
 

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -248,16 +248,20 @@ class BufferedMetricsLogger {
     }
 
     /**
-     * Calling `flush` sends any buffered metrics to Datadog. Unless you set
-     * `flushIntervalSeconds` to 0 it won't be necessary to call this function.
+     * Send buffered metrics to Datadog.
      *
-     * It can be useful to trigger a manual flush by calling if you want to
-     * make sure pending metrics have been sent before you quit the application
-     * process, for example.
-     * @param {() => void} [onSuccess] This argument is deprecated and will soon
-     *        be removed! Please use the returned promise instead.
-     * @param {(error: Error) => void} [onError] This argument is deprecated and
-     *        will soon be removed! Please use the returned promise instead.
+     * Unless you've set `flushIntervalSeconds` to 0, this will be called
+     * automatically for you. However, you may want to call it manually when
+     * your application quits to send any remaining metrics.
+     *
+     * Returns a promise indicating when sending has completed. Older support
+     * for success and error callbacks as arguments to this method is deprecated
+     * and will be removed in the future. Please switch to promises!
+     *
+     * @param {() => void} [onSuccess] DEPRECATED! This argument will be removed
+     *        soon. Please use the returned promise instead.
+     * @param {(error: Error) => void} [onError] DEPRECATED! This argument will
+     *        be removed soon. Please use the returned promise instead.
      * @returns {Promise}
      */
     flush(onSuccess, onError) {

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -1,18 +1,15 @@
 'use strict';
 const datadogApiClient = require('@datadog/datadog-api-client');
 const { AuthorizationError } = require('./errors');
-const { logDebug, logDeprecation, logError } = require('./logging');
+const { logDebug, logDeprecation } = require('./logging');
 
 /**
  * A Reporter that throws away metrics instead of sending them to Datadog. This
  * is useful for disabling metrics in your application and for tests.
  */
 class NullReporter {
-    report(series, onSuccess) {
+    async report(_series) {
         // Do nothing.
-        if (typeof onSuccess === 'function') {
-            onSuccess();
-        }
     }
 }
 
@@ -55,7 +52,12 @@ class DatadogReporter {
         datadogClients.set(this, new datadogApiClient.v1.MetricsApi(configuration));
     }
 
-    report(series, onSuccess, onError) {
+    /**
+     * Send an array of serialized metrics to Datadog.
+     * @param {any[]} series
+     * @returns {Promise}
+     */
+    async report(series) {
         logDebug('Calling report with %j', series);
 
         // Distributions must be submitted via a different method than other
@@ -84,31 +86,24 @@ class DatadogReporter {
             }));
         }
 
-        Promise.all(submissions)
-            .then(() => {
-                logDebug('sent metrics successfully');
-                if (typeof onSuccess === 'function') {
-                    onSuccess();
-                }
-            })
-            .catch((error) => {
-                if (error.code === 403) {
-                    error = new AuthorizationError(
-                        'Your Datadog API key is not authorized to send ' +
-                        'metrics. Check to make sure the DATADOG_API_KEY ' +
-                        'environment variable or the `apiKey` option is set ' +
-                        'to a valid API key for your Datadog account, and ' +
-                        'that it is not an *application* key. For more, see: ' +
-                        'https://docs.datadoghq.com/account_management/api-app-keys/',
-                        { cause: error }
-                    );
-                }
-                if (typeof onError === 'function') {
-                    onError(error);
-                } else {
-                    logError('failed to send metrics (err=%s)', error);
-                }
-            });
+        try {
+            await Promise.all(submissions);
+            logDebug('sent metrics successfully');
+        } catch (error) {
+            if (error.code === 403) {
+                throw new AuthorizationError(
+                    'Your Datadog API key is not authorized to send ' +
+                    'metrics. Check to make sure the DATADOG_API_KEY ' +
+                    'environment variable or the `apiKey` init option is set ' +
+                    'to a valid API key for your Datadog account, and ' +
+                    'that it is not an *application* key. For more, see: ' +
+                    'https://docs.datadoghq.com/account_management/api-app-keys/',
+                    { cause: error }
+                );
+            }
+
+            throw error;
+        }
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@types/node": "^12.20.55",
     "chai": "4.3.6",
+    "chai-as-promised": "^7.1.2",
     "chai-string": "1.5.0",
     "eslint": "^8.24.0",
     "mocha": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-metrics",
-  "version": "0.11.5-dev",
+  "version": "0.12.0-dev",
   "description": "Buffered metrics reporting via the Datadog HTTP API",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/test/loggers_tests.js
+++ b/test/loggers_tests.js
@@ -239,7 +239,13 @@ describe('BufferedMetricsLogger', function() {
                 it('should call the flush error handler with the reporter error', (done) => {
                     logger.flush(
                         () => done(new Error('The success handler was called!')),
-                        (error) => done(error === reporter.expectError ? null : new Error('Error was not the reporter error'))
+                        (error) => {
+                            if (error === reporter.expectError) {
+                                done();
+                            } else {
+                                done(new Error('Error was not the reporter error'));
+                            }
+                        }
                     );
                 });
 
@@ -281,7 +287,7 @@ describe('BufferedMetricsLogger', function() {
                             throw this.expectError;
                         }
                     }
-                }
+                };
             });
 
             standardFlushTests();
@@ -302,7 +308,7 @@ describe('BufferedMetricsLogger', function() {
                             }
                         }, 0);
                     }
-                }
+                };
             });
 
             standardFlushTests();

--- a/test/reporters_tests.js
+++ b/test/reporters_tests.js
@@ -52,7 +52,7 @@ describe('DatadogReporter', function() {
         });
     });
 
-    describe('flush', function() {
+    describe('report', function() {
         let reporter;
 
         beforeEach(() => {

--- a/test/reporters_tests.js
+++ b/test/reporters_tests.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const chai = require('chai');
+const nock = require('nock');
+
+chai.should();
+const { DatadogReporter, NullReporter } = require('../lib/reporters');
+const { AuthorizationError } = require('../lib/errors');
+
+describe('NullReporter', function() {
+    it('should always resolve', async function() {
+        const reporter = new NullReporter();
+        await reporter.report([{a: 'b'}, {c: 'd'}]);
+    });
+});
+
+describe('DatadogReporter', function() {
+    const mockMetric = {
+        metric: 'test.gauge',
+        points: [[Math.floor(Date.now() / 1000), 1]],
+        type: 'gauge',
+    };
+
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
+    describe('constructor', function() {
+        let originalEnv = Object.entries(process.env);
+
+        afterEach(() => {
+            for (const [key, value] of originalEnv) {
+                process.env[key] = value;
+            }
+        });
+
+        it('creates a DatadogReporter', () => {
+            const instance = new DatadogReporter('abc', '123', 'datadoghq.eu');
+            instance.should.be.an.instanceof(DatadogReporter);
+        });
+
+        it('reads the API key from environment if not specified', () => {
+            process.env.DATADOG_API_KEY = 'abc';
+            const instance = new DatadogReporter();
+            instance.should.be.an.instanceof(DatadogReporter);
+        });
+
+        it('throws if no API key is set', () => {
+            delete process.env.DATADOG_API_KEY;
+
+            (() => new DatadogReporter()).should.throw(/DATADOG_API_KEY/);
+        });
+    });
+
+    describe('flush', function() {
+        let reporter;
+
+        beforeEach(() => {
+            reporter = new DatadogReporter('abc');
+        });
+
+        it('should resolve on success', async function () {
+            nock('https://api.datadoghq.com')
+                .post('/api/v1/series')
+                .reply(202, { errors: [] });
+
+            await reporter.report([mockMetric]).should.be.fulfilled;
+        });
+
+        it('should reject on error', async function () {
+            nock('https://api.datadoghq.com')
+                .post('/api/v1/series')
+                .reply(500, { errors: ['Unknown!'] });
+
+            await reporter.report([mockMetric]).should.be.rejected;
+        });
+
+        it('rejects with AuthorizationError when the API key is invalid', async function() {
+            nock('https://api.datadoghq.com')
+                .post('/api/v1/series')
+                .reply(403, { errors: ['Forbidden'] });
+
+            await reporter.report([mockMetric]).should.be.rejectedWith(AuthorizationError);
+        })
+    });
+
+    it('should allow two instances to use different credentials', async function() {
+        const apiKeys = ['abc', 'xyz'];
+        let receivedKeys = [];
+
+        nock('https://api.datadoghq.com')
+            .matchHeader('dd-api-key', (values) => {
+                receivedKeys.push(values[0]);
+                return true;
+            })
+            .post('/api/v1/series')
+            .times(apiKeys.length)
+            .reply(202, { errors: [] });
+
+        const reporters = apiKeys.map(key => new DatadogReporter(key));
+        await Promise.all(reporters.map(r => r.report([mockMetric])));
+
+        receivedKeys.should.deep.equal(apiKeys);
+    });
+});

--- a/test/reporters_tests.js
+++ b/test/reporters_tests.js
@@ -7,20 +7,20 @@ chai.should();
 const { DatadogReporter, NullReporter } = require('../lib/reporters');
 const { AuthorizationError } = require('../lib/errors');
 
+const mockMetric = {
+    metric: 'test.gauge',
+    points: [[Math.floor(Date.now() / 1000), 1]],
+    type: 'gauge',
+};
+
 describe('NullReporter', function() {
     it('should always resolve', async function() {
         const reporter = new NullReporter();
-        await reporter.report([{a: 'b'}, {c: 'd'}]);
+        await reporter.report([mockMetric]);
     });
 });
 
 describe('DatadogReporter', function() {
-    const mockMetric = {
-        metric: 'test.gauge',
-        points: [[Math.floor(Date.now() / 1000), 1]],
-        type: 'gauge',
-    };
-
     afterEach(() => {
         nock.cleanAll();
     });
@@ -81,7 +81,7 @@ describe('DatadogReporter', function() {
                 .reply(403, { errors: ['Forbidden'] });
 
             await reporter.report([mockMetric]).should.be.rejectedWith(AuthorizationError);
-        })
+        });
     });
 
     it('should allow two instances to use different credentials', async function() {


### PR DESCRIPTION
This deprecates `onSuccess`/`onError` callbacks throughout the library and changes async functions to return promises instead. Fixes #84.

In the reporters, this lets us switch to using actual `async` functions which simplifies code slightly.

However, the main `flush()` function does not use the `async` keyword because it needs to call `catch()` on the promise it returns before actually returning it. This is a bit of a trick, and is meant to let users write code like:

```js
metrics.flush();
```

…without needing to worry about adding their own `catch()` handler. Without this, the above code would cause an async `UnhandledPromiseRejectionWarning` exception and crash their program. I *think* this is probably useful, but it is a bit special! Some alternatives:

1. Don’t worry about making this work. Users will need to write code like:

    ```js
    // Same behavior as above code; you don't care when it finishes flushing:
    metrics.flush().catch(() => null);

    // Or If you want to wait for it to be done:
    await metrics.flush().catch(() => null);
    ```

2. Make `flush()` never error, and instead resolve with some kind of object indicating success or failure. I’m not a huge fan of this approach, but it works.

---

One other minor change here is that providing an error callback used to prevent the global error handler from running, but no longer does. Since we don't know if someone is going to attach an error handler later to the promise we return we can no longer do this. That is, this:

```js
metrics.init({
  onError (error) {
    console.log('Global error handler called!', error);
  }
});
metrics.flush(
  () => console.log('ok'),
  (error) => console.log('Local error handler called!', error)
);
```

…used to only log `'Local error handler called!'`, but now logs both that *and* `'Global error handler called!'`.

I’m not too worried about this, and I think I probably should have set up the global error handler to work this way in the first place. 🤷 

---

@ErikBoesen we debated in #84 about deprecation vs. just making a breaking change. I decided to _deprecate_ here since we know folks are using custom reporters, and I think a breaking change for those would be much rougher than just changing the signature of the `flush()` method. Users are generally in control of how they call `flush()`, but may be using custom reporters from a third party. Supporting both adds a lot of code, though! 👍 👎 ?

We could also make it a breaking change for `flush()` (i.e. remove the callbacks from it), but still support callbacks in the reporters.