### PR TITLE
Use `Map` for aggregator buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,22 @@ npm test
 
 * In Development:
 
+    **Breaking Changes:**
+
     TBD
+
+    **New Features:**
+
+    TBD
+
+    **Bug Fixes:**
+
+    TBD
+
+    **Maintenance:**
+
+    * Buffer metrics using `Map` instead of a plain object.
+
 
     [View diff](https://github.com/dbader/node-datadog-metrics/compare/v0.11.4...main)
 

--- a/lib/aggregators.js
+++ b/lib/aggregators.js
@@ -6,7 +6,7 @@ class Aggregator {
      * @param {string[]} defaultTags
      */
     constructor(defaultTags) {
-        this.buffer = {};
+        this.buffer = new Map();
         this.defaultTags = defaultTags || [];
     }
 
@@ -18,16 +18,16 @@ class Aggregator {
 
     addPoint(Type, key, value, tags, host, timestampInMillis, options) {
         const bufferKey = this.makeBufferKey(key, tags);
-        if (!Object.prototype.hasOwnProperty.call(this.buffer, bufferKey)) {
-            this.buffer[bufferKey] = new Type(key, tags, host, options);
+        if (!this.buffer.has(bufferKey)) {
+            this.buffer.set(bufferKey, new Type(key, tags, host, options));
         }
 
-        this.buffer[bufferKey].addPoint(value, timestampInMillis);
+        this.buffer.get(bufferKey).addPoint(value, timestampInMillis);
     }
 
     flush() {
         let series = [];
-        for (const item of Object.values(this.buffer)) {
+        for (const item of this.buffer.values()) {
             series.push(...item.flush());
         }
 
@@ -38,7 +38,7 @@ class Aggregator {
             }
         }
 
-        this.buffer = {};
+        this.buffer.clear();
 
         return series;
     }


### PR DESCRIPTION
The `Map` object is built for our exact use-case here. It is faster and safer than using a plain JS object (what we currently do) or an object created with `Object.create(null)`. While this is a pretty minor improvement, it’s still worthwhile!

I meant to make this change a long time ago, and then managed to totally forget about it. 😅 