### PR TITLE
Drop support for application keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,13 @@ Where `options` is an object and can contain the following:
       is required to send metrics.
     * Make sure not to confuse this with your _application_ key! For more
       details, see: https://docs.datadoghq.com/account_management/api-app-keys/
-* `appKey`: Sets the Datadog application key. (optional)
-    * It's usually best to keep this in an environment variable. Datadog-metrics
-      looks for the application key in `DATADOG_APP_KEY` by default.
-    * This is different from the API key (see above), which is required. For
-      more about the different between API and application keys, see:
-      https://docs.datadoghq.com/account_management/api-app-keys/
+* `appKey`: ⚠️ Deprecated. This does nothing and will be removed in an upcoming
+    release.
+
+    Sets the Datadog _application_ key. This is not actually needed for sending
+    metrics or distributions, and you probably shouldn’t set it. Do not confuse
+    this with your _API_ key! For more, see:
+    https://docs.datadoghq.com/account_management/api-app-keys/
 * `defaultTags`: Default tags used for all metric reporting. (optional)
     * Set tags that are common to all metrics.
 * `onError`: A function to call when there are asynchronous errors seding
@@ -346,6 +347,7 @@ Contributions are always welcome! For more info on how to contribute or develop 
 
     * Buffer metrics using `Map` instead of a plain object.
 
+    * Deprecated the `appKey` option. Application keys (as opposed to API keys) are not actually needed for sending metrics or distributions to the Datadog API. Including it in your configuration adds not benefits, but risks exposing a sensitive credential.
 
     [View diff](https://github.com/dbader/node-datadog-metrics/compare/v0.11.4...main)
 

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Contributions are always welcome! For more info on how to contribute or develop 
 
     * Buffer metrics using `Map` instead of a plain object.
 
-    * Deprecated the `appKey` option. Application keys (as opposed to API keys) are not actually needed for sending metrics or distributions to the Datadog API. Including it in your configuration adds not benefits, but risks exposing a sensitive credential.
+    * Deprecated the `appKey` option. Application keys (as opposed to API keys) are not actually needed for sending metrics or distributions to the Datadog API. Including it in your configuration adds no benefits, but risks exposing a sensitive credential.
 
     [View diff](https://github.com/dbader/node-datadog-metrics/compare/v0.11.4...main)
 

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -40,7 +40,8 @@ const Distribution = require('./metrics').Distribution;
 /**
  * @typedef {object} BufferedMetricsLoggerOptions
  * @property {string} [apiKey] Datadog API key
- * @property {string} [appKey] Datadog APP key
+ * @property {string} [appKey] DEPRECATED: App keys aren't actually used for
+ *           metrics and are no longer supported.
  * @property {string} [host] Default host for all reported metrics
  * @property {string} [prefix] Default key prefix for all metrics
  * @property {string} [site] Sets the Datadog "site", or server where metrics
@@ -98,7 +99,7 @@ class BufferedMetricsLogger {
         /** @private */
         this.aggregator = opts.aggregator || new Aggregator(opts.defaultTags);
         /** @private @type {ReporterType} */
-        this.reporter = opts.reporter || new DatadogReporter(opts.apiKey, opts.appKey, opts.site);
+        this.reporter = opts.reporter || new DatadogReporter(opts.apiKey, opts.site);
         /** @private */
         this.host = opts.host;
         /** @private */

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -22,12 +22,24 @@ class DatadogReporter {
     /**
      * Create a reporter that sends metrics to Datadog's API.
      * @param {string} [apiKey]
-     * @param {string} [appKey]
+     * @param {string} [appKey] DEPRECATED! This argument does nothing.
      * @param {string} [site]
      */
     constructor(apiKey, appKey, site) {
+        if (appKey) {
+            if (!site && /(datadoghq|ddog-gov)\./.test(appKey)) {
+                site = appKey;
+                appKey = null;
+            } else {
+                logDeprecation(
+                    'The `appKey` option is no longer supported since it is ' +
+                    'not used for submitting metrics, distributions, events, ' +
+                    'or logs.'
+                );
+            }
+        }
+
         apiKey = apiKey || process.env.DATADOG_API_KEY;
-        appKey = appKey || process.env.DATADOG_APP_KEY;
         this.site = site || process.env.DATADOG_SITE || process.env.DATADOG_API_HOST;
 
         if (!apiKey) {
@@ -37,7 +49,6 @@ class DatadogReporter {
         const configuration = datadogApiClient.client.createConfiguration({
             authMethods: {
                 apiKeyAuth: apiKey,
-                appKeyAuth: appKey
             }
         });
         if (this.site) {


### PR DESCRIPTION
Every so often folks run into trouble by mixing up API and application keys. Back in #118, I added more documentation and error messaging to help clarify potential issues, but I also noticed that the application keys don’t actually seem to be needed.

I did some testing and it turns out they definitely are not needed for submitting metrics, distributions, events, or logs (we don’t do the last two, but there is an open issue about supporting events). As far as I can tell, there’s no way for Datadog users to tell what application key something was submitted with, so they really don’t seem to have any value at all for our current use cases. Given the narrow goals of this library, we probably don’t ever want to support more complicated stuff that we would need application keys for, either.

Support was originally added by @gert-fresh back in 2015/2016 in PR #7. There’s not much description there, but I *think* it was because this library used to configure a single, globally available Datadog client, so a developer using this library might *also* want to use that client to do other things requiring an application key. That’s no longer how things work here today (each reporter instance has its own client, and those clients are not available to user code). Assuming I understand that correctly, the original use case is obsolete.

⚠️ Removing this feature is actually more work than keeping it (see code for handling different numbers of arguments and logging deprecations), but I want to remove it because its existence encourages users to include an unnecessary credential in their apps, which increases their security risks. Maybe it’s not worth worrying about, though?

---

Total side note: I haven’t touched this package in a while, but a few recent issues brought my attention back to it, so I thought I’d do some work on old issues and ideas that have been kicking around here. I figure I’ll work on a bunch of updates that might deprecate some things (like this, or #125) in the next week or so, and then cut another release at the start of next year that actually removes all the deprecations and cleans things out. Maybe we require a more recent version of Node.js then, too, so we can update some of our dev tooling (much of which has moved on to requiring Node.js 18+, which we only require 12+ here).