### PR TITLE
Check that types are valid before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/dbader/node-datadog-metrics/issues"
   },
   "scripts": {
-    "prepack": "npm run clean && npm run build-types",
+    "prepack": "npm run clean && npm run build-types && npm run check-types",
     "test": "mocha --reporter spec",
     "check-codestyle": "npx eslint .",
     "check-text": "test/lint_text.sh",


### PR DESCRIPTION
In #120, I added a test of our built types. Since we do a clean build of the types before publishing, we should also do a final check of those build results just to avoid any accidental issues for things that weren't fully checked (usually CI protects us here, but since we publish manually, a final check is useful!).

I think this is pretty straightforward and I should have just done it as part of #120, so I’m going to go ahead and merge this tomorrow if there’s no feedback.