### PR TITLE
Rename `DATADOG_API_HOST` → `DATADOG_SITE`

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Where `options` is an object and can contain the following:
     * Defaults to `datadoghq.com`.
     * See more details on setting your site at:
         https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
+    * You can also set this via the `DATADOG_SITE` environment variable.
 * `apiKey`: Sets the Datadog API key. (optional)
     * It's usually best to keep this in an environment variable.
       Datadog-metrics looks for the API key in `DATADOG_API_KEY` by default.
@@ -317,7 +318,7 @@ npm test
 
     **Bug Fixes:**
 
-    TBD
+    * Support setting the `site` option via the `DATADOG_SITE` environment variable. The `apiHost` option was renamed to `site` in v0.11.0, but the `DATADOG_API_HOST` environment variable was accidentally left as-is. The old environment variable name is now deprecated, and will be removed at the same time as the `apiHost` option is removed.
 
     **Maintenance:**
 

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -75,13 +75,15 @@ class BufferedMetricsLogger {
      * @param {BufferedMetricsLoggerOptions} [opts]
      */
     constructor (opts) {
-        if (opts.apiHost) {
+        if (opts.apiHost || process.env.DATADOG_API_HOST) {
             logDeprecation(
-                'The `apiHost` option for `init()` and `BufferedMetricsLogger` ' +
-                'has been deprecated and will be removed in a future release. ' +
-                'Please use the `site` option instead.'
+                'The `apiHost` option (and `DATADOG_API_HOST` environment ' +
+                'variable) for `init()` and `BufferedMetricsLogger` has been ' +
+                'deprecated and will be removed in a future release. Please ' +
+                'use the `site` option (or `DATADOG_SITE` environment ' +
+                'variable) instead.'
             );
-            opts.site = opts.apiHost;
+            opts.site = opts.site || opts.apiHost;
         }
 
         /** @private */

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -31,7 +31,7 @@ class DatadogReporter {
     constructor(apiKey, appKey, site) {
         apiKey = apiKey || process.env.DATADOG_API_KEY;
         appKey = appKey || process.env.DATADOG_APP_KEY;
-        this.site = site || process.env.DATADOG_API_HOST;
+        this.site = site || process.env.DATADOG_SITE || process.env.DATADOG_API_HOST;
 
         if (!apiKey) {
             throw new Error('DATADOG_API_KEY environment variable not set');


### PR DESCRIPTION
Back in #100, I renamed the `apiHost` option to `site` (in order to match up with Datadog's own docs and terminology), but forgot to rename the corresponding environment variable. This deprecates `DATADOG_API_HOST` in favor of `DATADOG_SITE` (as should have been done before). We'll remove support for the old env var when we remove `apiHost`.