### PR TITLE
Support `DD_` env var prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ There's also a longer [tutorial](https://dbader.org/blog/monitoring-your-nodejs-
 
 ### Datadog API key
 
-Make sure the `DATADOG_API_KEY` environment variable is set to your Datadog
-API key (you can also set it via the `apiKey` option in code). You can find the API key under [Integrations > APIs](https://app.datadoghq.com/account/settings#api). *Please note the API key is different from an **application key**. For more details, see [Datadog’s “API and Application Keys” docs](https://docs.datadoghq.com/account_management/api-app-keys/).*
+Make sure the `DATADOG_API_KEY` or `DD_API_KEY` environment variable is set to your Datadog API key (you can also set it via the `apiKey` option in code). You can find the API key under [Integrations > APIs](https://app.datadoghq.com/account/settings#api). *Please note the API key is different from an **application key**. For more details, see [Datadog’s “API and Application Keys” docs](https://docs.datadoghq.com/account_management/api-app-keys/).*
 
 ### Module setup
 
@@ -121,10 +120,11 @@ Where `options` is an object and can contain the following:
     * Defaults to `datadoghq.com`.
     * See more details on setting your site at:
         https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
-    * You can also set this via the `DATADOG_SITE` environment variable.
+    * You can also set this via the `DATADOG_SITE` or `DD_SITE` environment variable.
 * `apiKey`: Sets the Datadog API key. (optional)
     * It's usually best to keep this in an environment variable.
-      Datadog-metrics looks for the API key in `DATADOG_API_KEY` by default.
+      Datadog-metrics looks for the API key in the `DATADOG_API_KEY` or
+      `DD_API_KEY` environment variable by default.
     * You must either set this option or the environment variable. An API key
       is required to send metrics.
     * Make sure not to confuse this with your _application_ key! For more
@@ -338,6 +338,8 @@ Contributions are always welcome! For more info on how to contribute or develop 
 
         * The `flush()` method now returns a promise.
         * The `report(series)` method on any custom reporters should now return a promise. For now, datadog-metrics will use the old callback-based behavior if the method signature has callbacks listed after `series` argument.
+
+    * Environment variables can now be prefixed with *either* `DATADOG_` or `DD_` (previously, only `DATADOG_` worked) in order to match configuration with the Datadog agent. For example, you can set your API key via `DATADOG_API_KEY` or `DD_API_KEY`.
 
     **Bug Fixes:**
 

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -39,11 +39,15 @@ class DatadogReporter {
             }
         }
 
-        apiKey = apiKey || process.env.DATADOG_API_KEY;
-        this.site = site || process.env.DATADOG_SITE || process.env.DATADOG_API_HOST;
+        apiKey = apiKey || process.env.DATADOG_API_KEY || process.env.DD_API_KEY;
+        this.site = site || process.env.DATADOG_SITE || process.env.DD_SITE || process.env.DATADOG_API_HOST;
 
         if (!apiKey) {
-            throw new Error('DATADOG_API_KEY environment variable not set');
+            throw new Error(
+                'Datadog API key not found. You must specify one via a ' +
+                'configuration option or the DATADOG_API_KEY (or DD_API_KEY) ' +
+                'environment variable.'
+            );
         }
 
         const configuration = datadogApiClient.client.createConfiguration({
@@ -104,10 +108,11 @@ class DatadogReporter {
             if (error.code === 403) {
                 throw new AuthorizationError(
                     'Your Datadog API key is not authorized to send ' +
-                    'metrics. Check to make sure the DATADOG_API_KEY ' +
-                    'environment variable or the `apiKey` init option is set ' +
-                    'to a valid API key for your Datadog account, and ' +
-                    'that it is not an *application* key. For more, see: ' +
+                    'metrics. Check to make sure the DATADOG_API_KEY or ' +
+                    'DD_API_KEY environment variable or the `apiKey` init ' +
+                    'option is set to a valid API key for your Datadog ' +
+                    'account, and that it is not an *application* key. ' +
+                    'For more, see: ' +
                     'https://docs.datadoghq.com/account_management/api-app-keys/',
                     { cause: error }
                 );

--- a/test/reporters_tests.js
+++ b/test/reporters_tests.js
@@ -29,9 +29,7 @@ describe('DatadogReporter', function() {
         let originalEnv = Object.entries(process.env);
 
         afterEach(() => {
-            for (const [key, value] of originalEnv) {
-                process.env[key] = value;
-            }
+            process.env = Object.fromEntries(originalEnv);
         });
 
         it('creates a DatadogReporter', () => {
@@ -39,15 +37,19 @@ describe('DatadogReporter', function() {
             instance.should.be.an.instanceof(DatadogReporter);
         });
 
-        it('reads the API key from environment if not specified', () => {
+        it('reads the API key from DATADOG_API_KEY environment if not specified', () => {
             process.env.DATADOG_API_KEY = 'abc';
             const instance = new DatadogReporter();
             instance.should.be.an.instanceof(DatadogReporter);
         });
 
-        it('throws if no API key is set', () => {
-            delete process.env.DATADOG_API_KEY;
+        it('reads the API key from DD_API_KEY environment if not specified', () => {
+            process.env.DD_API_KEY = 'abc';
+            const instance = new DatadogReporter();
+            instance.should.be.an.instanceof(DatadogReporter);
+        });
 
+        it('throws if no API key is set', () => {
             (() => new DatadogReporter()).should.throw(/DATADOG_API_KEY/);
         });
     });


### PR DESCRIPTION
All environment variables for this library are currently prefixed with `DATADOG_`. In order to match the configuration variables used by the Datadog agent, this supports the `DD_` prefix in addition to `DATADOG_`.

The goal here is just to make configuration easier to set up. Some Datadog tools use `DATADOG_`, while others (like the agent, which this package is most similar to) use `DD_`. Others support both! It’s not surprising if people get mixed up, or want to use one set of configuration vars for all their Datadog-related stuff, so we should make that work.

Fixes #135.