### PR TITLE
Retry on Datadog API errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ Where `options` is an object and can contain the following:
            the default.
         2. `reporters.NullReporter` throws the metrics away. It’s useful for
            tests or temporarily disabling your metrics.
+* `retries`: How many times to retry failed metric submissions to Datadog’s API.
+    * Defaults to `2`.
+    * Ignored if you set the `reporter` option.
+* `retryBackoff`: How long to wait before retrying a failed Datadog API call.
+    Subsequent retries multiply this delay by 2^(retry count). For example, if
+    this is set to `1`, retries will happen after 1, then 2, then 4 seconds.
+    * Defaults to `1`.
+    * Ignored if you set the `reporter` option.
 
 Example:
 
@@ -339,9 +347,13 @@ Contributions are always welcome! For more info on how to contribute or develop 
         * The `flush()` method now returns a promise.
         * The `report(series)` method on any custom reporters should now return a promise. For now, datadog-metrics will use the old callback-based behavior if the method signature has callbacks listed after `series` argument.
 
-    * Retries: flushes to Datadog’s API are now retried automatically. This can help you work around intermittent network issues or rate limits.
+    * Retries: flushes to Datadog’s API are now retried automatically. This can help you work around intermittent network issues or rate limits. To adjust retries, use the `retries` and `retryBackoff` options.
 
     * Environment variables can now be prefixed with *either* `DATADOG_` or `DD_` (previously, only `DATADOG_` worked) in order to match configuration with the Datadog agent. For example, you can set your API key via `DATADOG_API_KEY` or `DD_API_KEY`.
+
+    **Deprecations:**
+
+    * The `DatadogReporter` constructor now takes an options object instead of positional arguments. Support for positional arguments will be removed in v0.13.0.
 
     **Bug Fixes:**
 

--- a/README.md
+++ b/README.md
@@ -334,10 +334,12 @@ Contributions are always welcome! For more info on how to contribute or develop 
 
     **New Features:**
 
-    * Asynchronous actions now use promises instead of callbacks. In places where `onSuccess` and `onError` callbacks were used, they are now deprecated. Instead, those methods return promises (callbacks still work, but support will be removed in a future release). This affects:
+    * Promises: asynchronous actions now use promises instead of callbacks. In places where `onSuccess` and `onError` callbacks were used, they are now deprecated. Instead, those methods return promises (callbacks still work, but support will be removed in a future release). This affects:
 
         * The `flush()` method now returns a promise.
         * The `report(series)` method on any custom reporters should now return a promise. For now, datadog-metrics will use the old callback-based behavior if the method signature has callbacks listed after `series` argument.
+
+    * Retries: flushes to Datadog’s API are now retried automatically. This can help you work around intermittent network issues or rate limits.
 
     * Environment variables can now be prefixed with *either* `DATADOG_` or `DD_` (previously, only `DATADOG_` worked) in order to match configuration with the Datadog agent. For example, you can set your API key via `DATADOG_API_KEY` or `DD_API_KEY`.
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Where `options` is an object and can contain the following:
     * See more details on setting your site at:
         https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
     * You can also set this via the `DATADOG_SITE` or `DD_SITE` environment variable.
+    * Ignored if you set the `reporter` option.
 * `apiKey`: Sets the Datadog API key. (optional)
     * It's usually best to keep this in an environment variable.
       Datadog-metrics looks for the API key in the `DATADOG_API_KEY` or
@@ -129,6 +130,7 @@ Where `options` is an object and can contain the following:
       is required to send metrics.
     * Make sure not to confuse this with your _application_ key! For more
       details, see: https://docs.datadoghq.com/account_management/api-app-keys/
+    * Ignored if you set the `reporter` option.
 * `appKey`: ⚠️ Deprecated. This does nothing and will be removed in an upcoming
     release.
 
@@ -145,12 +147,6 @@ Where `options` is an object and can contain the following:
     same properties as the options object on the `histogram()` method. Options
     specified when calling the method are layered on top of this object.
     (optional)
-* `reporter`: An object that actually sends the buffered metrics. (optional)
-    * There are two built-in reporters you can use:
-        1. `reporters.DatadogReporter` sends metrics to Datadog’s API, and is
-           the default.
-        2. `reporters.NullReporter` throws the metrics away. It’s useful for
-           tests or temporarily disabling your metrics.
 * `retries`: How many times to retry failed metric submissions to Datadog’s API.
     * Defaults to `2`.
     * Ignored if you set the `reporter` option.
@@ -159,6 +155,12 @@ Where `options` is an object and can contain the following:
     this is set to `1`, retries will happen after 1, then 2, then 4 seconds.
     * Defaults to `1`.
     * Ignored if you set the `reporter` option.
+* `reporter`: An object that actually sends the buffered metrics. (optional)
+    * There are two built-in reporters you can use:
+        1. `reporters.DatadogReporter` sends metrics to Datadog’s API, and is
+           the default.
+        2. `reporters.NullReporter` throws the metrics away. It’s useful for
+           tests or temporarily disabling your metrics.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Contributions are always welcome! For more info on how to contribute or develop 
 
     **Breaking Changes:**
 
-    TBD
+    * The `DatadogReporter` constructor now takes an options object instead of positional arguments. Using this constructor directly is pretty rare, so this likely doesn’t affect you!
 
     **New Features:**
 
@@ -355,7 +355,7 @@ Contributions are always welcome! For more info on how to contribute or develop 
 
     **Deprecations:**
 
-    * The `DatadogReporter` constructor now takes an options object instead of positional arguments. Support for positional arguments will be removed in v0.13.0.
+    * The `appKey` option is no longer supported. Application keys (as opposed to API keys) are not actually needed for sending metrics or distributions to the Datadog API. Including it in your configuration adds no benefits, but risks exposing a sensitive credential.
 
     **Bug Fixes:**
 
@@ -364,8 +364,6 @@ Contributions are always welcome! For more info on how to contribute or develop 
     **Maintenance:**
 
     * Buffer metrics using `Map` instead of a plain object.
-
-    * Deprecated the `appKey` option. Application keys (as opposed to API keys) are not actually needed for sending metrics or distributions to the Datadog API. Including it in your configuration adds no benefits, but risks exposing a sensitive credential.
 
     [View diff](https://github.com/dbader/node-datadog-metrics/compare/v0.11.4...main)
 

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -39,7 +39,8 @@ const Distribution = require('./metrics').Distribution;
 
 /**
  * @typedef {object} BufferedMetricsLoggerOptions
- * @property {string} [apiKey] Datadog API key
+ * @property {string} [apiKey] Datadog API key. Ignored if you set the
+ *           `reporter` option.
  * @property {string} [appKey] DEPRECATED: App keys aren't actually used for
  *           metrics and are no longer supported.
  * @property {string} [host] Default host for all reported metrics
@@ -66,6 +67,11 @@ const Distribution = require('./metrics').Distribution;
  *           metrics between flushes.
  * @property {ReporterType} [reporter] An object that actually sends the
  *           buffered metrics.
+ * @property {number} [retries] How many times to retry failed attempts to send
+ *           metrics to Datadog's API. Ignored if you set the `reporter` option.
+ * @property {number} [retryBackoff] How many seconds to wait before retrying a
+ *           failed API request. Subsequent retries will multiply this delay.
+ *           Ignored if you set the `reporter` option.
  */
 
 /**
@@ -101,7 +107,9 @@ class BufferedMetricsLogger {
         /** @private @type {ReporterType} */
         this.reporter = opts.reporter || new DatadogReporter({
             apiKey: opts.apiKey,
-            site: opts.site
+            site: opts.site,
+            retries: opts.retries,
+            retryBackoff: opts.retryBackoff
         });
         /** @private */
         this.host = opts.host;

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -46,7 +46,8 @@ const Distribution = require('./metrics').Distribution;
  * @property {string} [host] Default host for all reported metrics
  * @property {string} [prefix] Default key prefix for all metrics
  * @property {string} [site] Sets the Datadog "site", or server where metrics
- *           are sent. For details and options, see:
+ *           are sent. Ignored if you set the `reporter` option.
+ *           For details and options, see:
  *           https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
  * @property {string} [apiHost] DEPRECATED: Please use `site` instead.
  * @property {number} [flushIntervalSeconds] How often to send metrics to

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -99,7 +99,10 @@ class BufferedMetricsLogger {
         /** @private */
         this.aggregator = opts.aggregator || new Aggregator(opts.defaultTags);
         /** @private @type {ReporterType} */
-        this.reporter = opts.reporter || new DatadogReporter(opts.apiKey, opts.site);
+        this.reporter = opts.reporter || new DatadogReporter({
+            apiKey: opts.apiKey,
+            site: opts.site
+        });
         /** @private */
         this.host = opts.host;
         /** @private */

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -15,6 +15,100 @@ class NullReporter {
 
 const datadogClients = new WeakMap();
 
+async function sleep(milliseconds) {
+    await new Promise((r) => setTimeout(r, milliseconds));
+}
+
+const RETRYABLE_ERROR_CODES = new Set([
+    'ECONNREFUSED',
+    'ECONNRESET',
+    'ENOTFOUND',
+    'EPIPE',
+    'ETIMEDOUT'
+]);
+
+/**
+ * @private
+ * A custom HTTP implementation for Datadog that retries failed requests.
+ * Datadog has retries built in, but they don't handle network errors (just
+ * HTTP errors), and we want to retry in both cases. This inherits from the
+ * built-in HTTP library since we want to use the same fetch implementation
+ * Datadog uses instead of adding another dependency.
+ */
+class RetryHttp extends datadogApiClient.client.IsomorphicFetchHttpLibrary {
+    constructor(options) {
+        super(options);
+
+        // HACK: ensure enableRetry is always `false` so the base class logic
+        // does not actually retry (since we manage retries here).
+        Object.defineProperty(this, 'enableRetry', {
+            get () { return false; },
+            set () {},
+        });
+    }
+
+    async send(request) {
+        let i = 0;
+        while (true) {  // eslint-disable-line no-constant-condition
+            try {
+                const response = await super.send(request);
+                if (this.isRetryable(response, i)) {
+                    await sleep(this.retryDelay(response, i));
+                } else {
+                    return response;
+                }
+            } catch (error) {
+                if (this.isRetryable(error, i)) {
+                    await sleep(this.retryDelay(error, i));
+                } else {
+                    throw error;
+                }
+            }
+
+            i++;
+        }
+    }
+
+    /**
+     * @private
+     * @param {any} response HTTP response or error object
+     * @returns {boolean}
+     */
+    isRetryable(response, tryCount) {
+        return tryCount < this.maxRetries && (
+            RETRYABLE_ERROR_CODES.has(response.code)
+            || response.httpStatusCode === 429
+            || response.httpStatusCode >= 500
+        );
+    }
+
+    /**
+     * @private
+     * @param {any} response HTTP response or error object
+     * @param {number} tryCount
+     * @returns {number}
+     */
+    retryDelay(response, tryCount) {
+        if (response.httpStatusCode === 429) {
+            // Datadog's official client supports just the 'x-ratelimit-reset'
+            // header, so we support that here in addition to the standardized
+            // 'retry-after' heaer.
+            // There is also an upcoming IETF standard for 'ratelimit', but it
+            // has moved away from the syntax used in 'x-ratelimit-reset'. This
+            // stuff might change in the future.
+            // https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/
+            const delayHeader = response.headers['retry-after']
+                || response.headers['x-ratelimit-reset'];
+            const delayValue = parseInt(delayHeader, 10);
+            if (isNaN(delayValue) && delayValue > 0) {
+                return delayValue * 1000;
+            }
+        }
+
+        return this.backoffMultiplier ** tryCount * this.backoffBase * 1000;
+    }
+}
+
 /**
  * @typedef {Object} DatadogReporterOptions
  * @property {string} [apiKey] Datadog API key.
@@ -79,9 +173,9 @@ class DatadogReporter {
             authMethods: {
                 apiKeyAuth: apiKey,
             },
+            httpApi: new RetryHttp({}),
             // @ts-expect-error Guaranteed to have an options object here.
             maxRetries: options.retries >= 0 ? options.retries : 2,
-            enableRetry: true
         });
 
         // HACK: Specify backoff here rather than in configration options to

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -3,6 +3,18 @@ const datadogApiClient = require('@datadog/datadog-api-client');
 const { AuthorizationError } = require('./errors');
 const { logDebug, logDeprecation } = require('./logging');
 
+const RETRYABLE_ERROR_CODES = new Set([
+    'ECONNREFUSED',
+    'ECONNRESET',
+    'ENOTFOUND',
+    'EPIPE',
+    'ETIMEDOUT'
+]);
+
+async function sleep(milliseconds) {
+    await new Promise((r) => setTimeout(r, milliseconds));
+}
+
 /**
  * A Reporter that throws away metrics instead of sending them to Datadog. This
  * is useful for disabling metrics in your application and for tests.
@@ -13,20 +25,6 @@ class NullReporter {
     }
 }
 
-const datadogClients = new WeakMap();
-
-async function sleep(milliseconds) {
-    await new Promise((r) => setTimeout(r, milliseconds));
-}
-
-const RETRYABLE_ERROR_CODES = new Set([
-    'ECONNREFUSED',
-    'ECONNRESET',
-    'ENOTFOUND',
-    'EPIPE',
-    'ETIMEDOUT'
-]);
-
 /**
  * @private
  * A custom HTTP implementation for Datadog that retries failed requests.
@@ -36,7 +34,7 @@ const RETRYABLE_ERROR_CODES = new Set([
  * Datadog uses instead of adding another dependency.
  */
 class RetryHttp extends datadogApiClient.client.IsomorphicFetchHttpLibrary {
-    constructor(options) {
+    constructor(options = {}) {
         super(options);
 
         // HACK: ensure enableRetry is always `false` so the base class logic
@@ -50,19 +48,19 @@ class RetryHttp extends datadogApiClient.client.IsomorphicFetchHttpLibrary {
     async send(request) {
         let i = 0;
         while (true) {  // eslint-disable-line no-constant-condition
+            let response, error;
             try {
-                const response = await super.send(request);
-                if (this.isRetryable(response, i)) {
-                    await sleep(this.retryDelay(response, i));
-                } else {
-                    return response;
-                }
-            } catch (error) {
-                if (this.isRetryable(error, i)) {
-                    await sleep(this.retryDelay(error, i));
-                } else {
-                    throw error;
-                }
+                response = await super.send(request);
+            } catch (e) {
+                error = e;
+            }
+
+            if (this.isRetryable(response || error, i)) {
+                await sleep(this.retryDelay(response || error, i));
+            } else if (response) {
+                return response;
+            } else {
+                throw error;
             }
 
             i++;
@@ -100,7 +98,7 @@ class RetryHttp extends datadogApiClient.client.IsomorphicFetchHttpLibrary {
             const delayHeader = response.headers['retry-after']
                 || response.headers['x-ratelimit-reset'];
             const delayValue = parseInt(delayHeader, 10);
-            if (isNaN(delayValue) && delayValue > 0) {
+            if (!isNaN(delayValue) && delayValue > 0) {
                 return delayValue * 1000;
             }
         }
@@ -118,6 +116,9 @@ class RetryHttp extends datadogApiClient.client.IsomorphicFetchHttpLibrary {
  * @property {number} [retryBackoff] Delay before retries. Subsequent retries
  *           wait this long multiplied by 2^(retry count).
  */
+
+/** @type {WeakMap<DatadogReporter, datadogApiClient.v1.MetricsApi>} */
+const datadogClients = new WeakMap();
 
 /**
  * Create a reporter that sends metrics to Datadog's API.
@@ -164,7 +165,7 @@ class DatadogReporter {
         if (!apiKey) {
             throw new Error(
                 'Datadog API key not found. You must specify one via a ' +
-                'configuration option or the DATADOG_API_KEY (or DD_API_KEY) ' +
+                'configuration option or the DATADOG_API_KEY or DD_API_KEY ' +
                 'environment variable.'
             );
         }
@@ -173,7 +174,7 @@ class DatadogReporter {
             authMethods: {
                 apiKeyAuth: apiKey,
             },
-            httpApi: new RetryHttp({}),
+            httpApi: new RetryHttp(),
             // @ts-expect-error Guaranteed to have an options object here.
             maxRetries: options.retries >= 0 ? options.retries : 2,
         });
@@ -181,10 +182,8 @@ class DatadogReporter {
         // HACK: Specify backoff here rather than in configration options to
         // support values less than 2 (mainly for faster tests).
         // @ts-expect-error Guaranteed to have an options object here.
-        if (options.retryBackoff) {
-            // @ts-expect-error Guaranteed to have an options object here.
-            configuration.httpApi.backoffBase = options.retryBackoff;
-        }
+        const backoff = options.retryBackoff >= 0 ? options.retryBackoff : 1;
+        configuration.httpApi.backoffBase = backoff;
 
         if (this.site) {
             // Strip leading `app.` from the site in case someone copy/pasted the

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -16,31 +16,56 @@ class NullReporter {
 const datadogClients = new WeakMap();
 
 /**
+ * @typedef {Object} DatadogReporterOptions
+ * @property {string} [apiKey] Datadog API key.
+ * @property {string} [appKey] DEPRECATED! This option does nothing.
+ * @property {string} [site] The Datadog "site" to send metrics to.
+ * @property {number} [retries] Retry failed requests up to this many times.
+ * @property {number} [retryBackoff] Delay before retries. Subsequent retries
+ *           wait this long multiplied by 2^(retry count).
+ */
+
+/**
  * Create a reporter that sends metrics to Datadog's API.
  */
 class DatadogReporter {
     /**
      * Create a reporter that sends metrics to Datadog's API.
-     * @param {string} [apiKey]
+     * @param {DatadogReporterOptions|string} [options] Options or API key
+     *        string (the API key string type is deprecated and will be removed in the future).
      * @param {string} [appKey] DEPRECATED! This argument does nothing.
-     * @param {string} [site]
+     * @param {string} [site] DEPRECATED! Please use options instead.
      */
-    constructor(apiKey, appKey, site) {
-        if (appKey) {
-            if (!site && /(datadoghq|ddog-gov)\./.test(appKey)) {
-                site = appKey;
-                appKey = null;
-            } else {
-                logDeprecation(
-                    'The `appKey` option is no longer supported since it is ' +
-                    'not used for submitting metrics, distributions, events, ' +
-                    'or logs.'
-                );
-            }
+    constructor(options = {}, appKey, site) {
+        if (options == null || typeof options === 'string') {
+            logDeprecation(
+                'Positional arguments for DatadogReporter are deprecated. ' +
+                'Pass an options object as the only argument instead.'
+            );
+            options = {
+                // @ts-expect-error The TS compiler infers the wrong type here.
+                apiKey: options,
+                appKey,
+                site
+            };
         }
 
-        apiKey = apiKey || process.env.DATADOG_API_KEY || process.env.DD_API_KEY;
-        this.site = site || process.env.DATADOG_SITE || process.env.DD_SITE || process.env.DATADOG_API_HOST;
+        // @ts-expect-error Guaranteed to have an options object here.
+        if (options.appKey) {
+            logDeprecation(
+                'The `appKey` option is no longer supported since it is ' +
+                'not used for submitting metrics, distributions, events, ' +
+                'or logs.'
+            );
+        }
+
+        // @ts-expect-error Guaranteed to have an options object here.
+        const apiKey = options.apiKey || process.env.DATADOG_API_KEY || process.env.DD_API_KEY;
+        // @ts-expect-error Guaranteed to be an options object here.
+        this.site = options.site
+            || process.env.DATADOG_SITE
+            || process.env.DD_SITE
+            || process.env.DATADOG_API_HOST;
 
         if (!apiKey) {
             throw new Error(
@@ -53,8 +78,20 @@ class DatadogReporter {
         const configuration = datadogApiClient.client.createConfiguration({
             authMethods: {
                 apiKeyAuth: apiKey,
-            }
+            },
+            // @ts-expect-error Guaranteed to have an options object here.
+            maxRetries: options.retries >= 0 ? options.retries : 2,
+            enableRetry: true
         });
+
+        // HACK: Specify backoff here rather than in configration options to
+        // support values less than 2 (mainly for faster tests).
+        // @ts-expect-error Guaranteed to have an options object here.
+        if (options.retryBackoff) {
+            // @ts-expect-error Guaranteed to have an options object here.
+            configuration.httpApi.backoffBase = options.retryBackoff;
+        }
+
         if (this.site) {
             // Strip leading `app.` from the site in case someone copy/pasted the
             // URL from their web browser. More details on correct configuration:
@@ -64,6 +101,7 @@ class DatadogReporter {
                 site: this.site
             });
         }
+
         datadogClients.set(this, new datadogApiClient.v1.MetricsApi(configuration));
     }
 
@@ -139,7 +177,7 @@ class DataDogReporter extends DatadogReporter {
             'DataDogReporter has been renamed to DatadogReporter (lower-case ' +
             'D in "dog"); the old name will be removed in a future release.'
         );
-        super(apiKey, appKey, site);
+        super({ apiKey, appKey, site });
     }
 }
 

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -126,26 +126,13 @@ const datadogClients = new WeakMap();
 class DatadogReporter {
     /**
      * Create a reporter that sends metrics to Datadog's API.
-     * @param {DatadogReporterOptions|string} [options] Options or API key
-     *        string (the API key string type is deprecated and will be removed in the future).
-     * @param {string} [appKey] DEPRECATED! This argument does nothing.
-     * @param {string} [site] DEPRECATED! Please use options instead.
+     * @param {DatadogReporterOptions} [options]
      */
-    constructor(options = {}, appKey, site) {
-        if (options == null || typeof options === 'string') {
-            logDeprecation(
-                'Positional arguments for DatadogReporter are deprecated. ' +
-                'Pass an options object as the only argument instead.'
-            );
-            options = {
-                // @ts-expect-error The TS compiler infers the wrong type here.
-                apiKey: options,
-                appKey,
-                site
-            };
+    constructor(options = {}) {
+        if (typeof options !== 'object') {
+            throw new TypeError('DatadogReporter takes an options object, not multiple string arguments.');
         }
 
-        // @ts-expect-error Guaranteed to have an options object here.
         if (options.appKey) {
             logDeprecation(
                 'The `appKey` option is no longer supported since it is ' +
@@ -154,9 +141,7 @@ class DatadogReporter {
             );
         }
 
-        // @ts-expect-error Guaranteed to have an options object here.
         const apiKey = options.apiKey || process.env.DATADOG_API_KEY || process.env.DD_API_KEY;
-        // @ts-expect-error Guaranteed to be an options object here.
         this.site = options.site
             || process.env.DATADOG_SITE
             || process.env.DD_SITE
@@ -164,9 +149,9 @@ class DatadogReporter {
 
         if (!apiKey) {
             throw new Error(
-                'Datadog API key not found. You must specify one via a ' +
-                'configuration option or the DATADOG_API_KEY or DD_API_KEY ' +
-                'environment variable.'
+                'Datadog API key not found. You must specify one via the ' +
+                '`apiKey` configuration option or the DATADOG_API_KEY or ' +
+                'DD_API_KEY environment variable.'
             );
         }
 
@@ -175,13 +160,11 @@ class DatadogReporter {
                 apiKeyAuth: apiKey,
             },
             httpApi: new RetryHttp(),
-            // @ts-expect-error Guaranteed to have an options object here.
             maxRetries: options.retries >= 0 ? options.retries : 2,
         });
 
         // HACK: Specify backoff here rather than in configration options to
         // support values less than 2 (mainly for faster tests).
-        // @ts-expect-error Guaranteed to have an options object here.
         const backoff = options.retryBackoff >= 0 ? options.retryBackoff : 1;
         configuration.httpApi.backoffBase = backoff;
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "^1.16.0",
+    "@datadog/datadog-api-client": "^1.17.0",
     "debug": "^4.1.0"
   },
   "engines": {

--- a/test/reporters_tests.js
+++ b/test/reporters_tests.js
@@ -33,7 +33,10 @@ describe('DatadogReporter', function() {
         });
 
         it('creates a DatadogReporter', () => {
-            const instance = new DatadogReporter('abc', '123', 'datadoghq.eu');
+            const instance = new DatadogReporter({
+                apiKey: 'abc',
+                site: 'datadoghq.eu'
+            });
             instance.should.be.an.instanceof(DatadogReporter);
         });
 
@@ -58,7 +61,10 @@ describe('DatadogReporter', function() {
         let reporter;
 
         beforeEach(() => {
-            reporter = new DatadogReporter('abc');
+            reporter = new DatadogReporter({
+                apiKey: 'abc',
+                retryBackoff: 0.01
+            });
         });
 
         it('should resolve on success', async function () {
@@ -72,9 +78,22 @@ describe('DatadogReporter', function() {
         it('should reject on error', async function () {
             nock('https://api.datadoghq.com')
                 .post('/api/v1/series')
+                .times(3)
                 .reply(500, { errors: ['Unknown!'] });
 
             await reporter.report([mockMetric]).should.be.rejected;
+        });
+
+        it('should retry on error', async function () {
+            nock('https://api.datadoghq.com')
+                .post('/api/v1/series')
+                .times(1)
+                .reply(500, { errors: ['Unknown!'] })
+                .post('/api/v1/series')
+                .times(1)
+                .reply(202, { errors: [] });
+
+            await reporter.report([mockMetric]).should.be.fulfilled;
         });
 
         it('rejects with AuthorizationError when the API key is invalid', async function() {
@@ -99,7 +118,7 @@ describe('DatadogReporter', function() {
             .times(apiKeys.length)
             .reply(202, { errors: [] });
 
-        const reporters = apiKeys.map(key => new DatadogReporter(key));
+        const reporters = apiKeys.map(apiKey => new DatadogReporter({ apiKey }));
         await Promise.all(reporters.map(r => r.report([mockMetric])));
 
         receivedKeys.should.deep.equal(apiKeys);


### PR DESCRIPTION
This adds retry support for submitting metrics. It’s rare, but at scale most users have probably encountered some failures to send metrics (although they might not have noticed it in their logs). Fixes #108. **This is the last major item for v0.13.0!**

There are a bunch of ways to approach retries, but they fall into two main categories:
1. Retry API requests N times if they fail.
2. Keep a queue of metrics to send and add failed metrics back onto that queue. Then automatically get retried on the next flush.

I took approach 1 here, since it was much simpler to implement in the current architecture. For long running services (e.g. a web server), approach 2 is probably slightly better, but after some brief experimentation, it felt like implementing it required a lot of coordination work between the reporter and logger about what failures are retryable, and new tooling for measuring the size of a metric object to manage the queue size. We might still want to do it in the future, but I wanted to keep things a little simpler for now.

The underlying `@datadog/datadog-api-client` library added built-in retry support in v1.17.0, but it turns out to only retry on HTTP errors (when the server responds with a >= 400 status code) and not on network errors (e.g. broken connections). In my experience network errors make up a lot of the actual failures in practice, so those are important to cover. So this implementation includes a complete (but simple) retry and backoff algorithm instead of relying on the builtins. 🤷 

You can configure retries through the `retries` (how many) and `retryBackoff` (how long to delay) options:

```js
metrics.init({
  // The default is 2.
  retries: 3,

  // The default is 1.
  // Subsequent retries multiply this by powers of two, so this produces retries after:
  //   1 second, 2 seconds, 4 seconds
  retryBackoff: 1
});
```

⚠️ ~**Still not sure about:** This changes the constructor for `DatadogReporter` to use an options object instead of positional arguments, since it has so many options now. I’ve deprecated the old positional arguments signature, but I doubt direct usage of that class is common, so it might be fine to just make a breaking change (the only example I could find in real code on GitHub only uses it to support the `DD_API_KEY` environment variable, with I made work automatically in #135). Will sleep on it before merging.~ *(Update: made this a breaking change.)*