### PR TITLE
Auto-flush on process exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ By default, datadog-metrics will automatically flush, or send accumulated
 metrics to Datadog, at regular intervals, and, in environments that support it,
 before your program exits. (However, if you call `process.exit()` to cause a
 hard exit, datadog-metrics doesn’t get a chance to flush. In this case, you may
-want to call `await metrics.flush()`.)
+want to call `await metrics.stop()` first.)
 
 You can adjust the interval by using the `flushIntervalSeconds` option. Setting
 it to `0` will disable auto-flushing entirely:
@@ -298,7 +298,8 @@ it to `0` will disable auto-flushing entirely:
 metrics.init({ flushIntervalSeconds: 10 });
 ```
 
-You can also send accumulated metrics manually by calling `metrics.flush()`.
+You can also send accumulated metrics manually at any time by calling
+`metrics.flush()`.
 
 Please note that, when calling the `BufferedMetricsLogger` constructor directly,
 `flushIntervalSeconds` defaults to `0` instead. When constructing your own
@@ -335,6 +336,18 @@ metrics.flush()
     .then(() => console.log('Flush succeeded'))
     .catch((error) => console.log('Flush error:', error)) ;
 ```
+
+#### `metrics.stop(options)`
+
+Stops auto-flushing (if enabled) and flushes any currently buffered metrics.
+This is mainly useful if you want to manually clean up and send remaining
+metrics before hard-quitting your program (usually by calling `process.exit()`).
+Returns a promise for the result of the flush.
+
+Takes an optional object with properties:
+* `flush` (boolean) Whether to flush any remaining metrics after stopping.
+    Defaults to `true`.
+
 
 ## Logging
 

--- a/index.js
+++ b/index.js
@@ -35,6 +35,12 @@ function callOnSharedLogger(func) {
     // compiler that this satisfies the types. :(
     return (...args) => {
         if (sharedLogger === null) {
+            // Special case: don't make a new logger just to close it.
+            // @ts-expect-error TypeScript compiler can't figure this one out.
+            if (func === BufferedMetricsLogger.prototype.close) {
+                return Promise.resolve(undefined);
+            }
+
             init();
         }
         return func.apply(sharedLogger, args);
@@ -44,6 +50,7 @@ function callOnSharedLogger(func) {
 module.exports = {
     init,
     flush: callOnSharedLogger(BufferedMetricsLogger.prototype.flush),
+    close: callOnSharedLogger(BufferedMetricsLogger.prototype.close),
     gauge: callOnSharedLogger(BufferedMetricsLogger.prototype.gauge),
     increment: callOnSharedLogger(BufferedMetricsLogger.prototype.increment),
     histogram: callOnSharedLogger(BufferedMetricsLogger.prototype.histogram),

--- a/index.js
+++ b/index.js
@@ -35,9 +35,9 @@ function callOnSharedLogger(func) {
     // compiler that this satisfies the types. :(
     return (...args) => {
         if (sharedLogger === null) {
-            // Special case: don't make a new logger just to close it.
+            // Special case: don't make a new logger just to stop it.
             // @ts-expect-error TypeScript compiler can't figure this one out.
-            if (func === BufferedMetricsLogger.prototype.close) {
+            if (func === BufferedMetricsLogger.prototype.stop) {
                 return Promise.resolve(undefined);
             }
 
@@ -50,7 +50,7 @@ function callOnSharedLogger(func) {
 module.exports = {
     init,
     flush: callOnSharedLogger(BufferedMetricsLogger.prototype.flush),
-    close: callOnSharedLogger(BufferedMetricsLogger.prototype.close),
+    stop: callOnSharedLogger(BufferedMetricsLogger.prototype.stop),
     gauge: callOnSharedLogger(BufferedMetricsLogger.prototype.gauge),
     increment: callOnSharedLogger(BufferedMetricsLogger.prototype.increment),
     histogram: callOnSharedLogger(BufferedMetricsLogger.prototype.histogram),

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -360,12 +360,13 @@ class BufferedMetricsLogger {
      * Shut down the metrics logger. This will flush any buffered metrics and
      * disable future auto-flushing.
      * @param {Object} [options]
-     * @param {boolean} [options.flush=true] Whether to flush before returning.
+     * @param {boolean} [options.flush] Whether to flush before returning.
      *        Defaults to true.
+     * @returns {Promise}
      */
-    async close({ flush = true } = {}) {
+    async close(options) {
         this.flushIntervalSeconds = 0;
-        if (flush) {
+        if (options && options.flush) {
             await this.flush();
         }
     }

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -126,6 +126,8 @@ class BufferedMetricsLogger {
             set(value) {
                 if (value < 0) {
                     throw new TypeError(`flushIntervalSeconds must be >= 0 (got: ${value})`);
+                } else if (value === flushIntervalSeconds) {
+                    return;
                 }
 
                 flushIntervalSeconds = value;

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -7,6 +7,9 @@ const Counter = require('./metrics').Counter;
 const Histogram = require('./metrics').Histogram;
 const Distribution = require('./metrics').Distribution;
 
+const supportsProcessExit = typeof process !== 'undefined'
+    && typeof process.once === 'function';
+
 /**
  * @typedef {object} AggregatorType Buffers metrics to send.
  * @property {(
@@ -103,54 +106,8 @@ class BufferedMetricsLogger {
             opts.site = opts.site || opts.apiHost;
         }
 
-        let flushIntervalSeconds = 0;
-        let flushTimer = null;
-
-        const autoFlushCallback = () => {
-            this.flush();
-            if (this.flushIntervalSeconds) {
-                const interval = this.flushIntervalSeconds * 1000;
-                flushTimer = setTimeout(autoFlushCallback, interval);
-                // Let the event loop exit if this is the only active timer.
-                if (flushTimer.unref) flushTimer.unref();
-            }
-        };
-
-        const exitHandler = () => {
-            logDebug('Auto-flushing before process exits...');
-            this.flush();
-        };
-
-        Object.defineProperty(this, 'flushIntervalSeconds', {
-            get() { return flushIntervalSeconds; },
-            set(value) {
-                if (value < 0) {
-                    throw new TypeError(`flushIntervalSeconds must be >= 0 (got: ${value})`);
-                } else if (value === flushIntervalSeconds) {
-                    return;
-                }
-
-                flushIntervalSeconds = value;
-
-                // TODO: if autoflushing was already happening, the next auto-
-                // flush should ideally happen N seconds after the last auto-
-                // flush, not N seconds from now.
-                clearTimeout(flushTimer);
-                if (flushIntervalSeconds > 0) {
-                    logDebug('Auto-flushing every %d seconds', flushIntervalSeconds);
-                    autoFlushCallback();
-                } else {
-                    logDebug('Auto-flushing is disabled');
-                }
-
-                if (typeof process !== 'undefined' && typeof process.once === 'function') {
-                    process.off('beforeExit', exitHandler);
-                    if (flushIntervalSeconds > 0) {
-                        process.once('beforeExit', exitHandler);
-                    }
-                }
-            }
-        });
+        this.performAutoFlush = this.performAutoFlush.bind(this);
+        this.handleProcessExit = this.handleProcessExit.bind(this);
 
         /** @private */
         this.aggregator = opts.aggregator || new Aggregator(opts.defaultTags);
@@ -166,16 +123,27 @@ class BufferedMetricsLogger {
         /** @private */
         this.prefix = opts.prefix || '';
         /** @private */
-        this.flushIntervalSeconds = opts.flushIntervalSeconds;
-        /** @private */
         this.histogramOptions = opts.histogram;
 
+        /** @private */
+        this.onError = null;
         if (typeof opts.onError === 'function') {
-            /** @private */
             this.onError = opts.onError;
         } else if (opts.onError != null) {
             throw new TypeError('The `onError` option must be a function');
         }
+
+        /** @private */
+        this.flushTimer = null;
+        /** @private */
+        this.flushIntervalSeconds = 0;
+        if (opts.flushIntervalSeconds < 0) {
+            throw new TypeError(`flushIntervalSeconds must be >= 0 (got: ${opts.flushIntervalSeconds})`);
+        } else {
+            this.flushIntervalSeconds = opts.flushIntervalSeconds;
+        }
+
+        this.start();
     }
 
     /**
@@ -359,18 +327,57 @@ class BufferedMetricsLogger {
     }
 
     /**
-     * Shut down the metrics logger. This will flush any buffered metrics and
-     * disable future auto-flushing.
+     * Start auto-flushing metrics.
+     */
+    start() {
+        if (this.flushTimer) {
+            logDebug('Auto-flushing is already enabled');
+        } else if (this.flushIntervalSeconds > 0) {
+            logDebug('Auto-flushing every %d seconds', this.flushIntervalSeconds);
+            if (supportsProcessExit) {
+                process.once('beforeExit', this.handleProcessExit);
+            }
+            this.performAutoFlush();
+        } else {
+            logDebug('Auto-flushing is disabled');
+        }
+    }
+
+    /**
+     * Stop auto-flushing metrics. By default, this will also flush any
+     * currently buffered metrics. You can leave them in the buffer and not
+     * flush by setting the `flush` option to `false`.
      * @param {Object} [options]
      * @param {boolean} [options.flush] Whether to flush before returning.
      *        Defaults to true.
      * @returns {Promise}
      */
-    async close(options) {
-        this.flushIntervalSeconds = 0;
-        if (options && options.flush) {
+    async stop(options) {
+        clearTimeout(this.flushTimer);
+        this.flushTimer = null;
+        if (supportsProcessExit) {
+            process.off('beforeExit', this.handleProcessExit);
+        }
+        if (!options || options.flush) {
             await this.flush();
         }
+    }
+
+    /** @private */
+    performAutoFlush() {
+        this.flush();
+        if (this.flushIntervalSeconds) {
+            const interval = this.flushIntervalSeconds * 1000;
+            this.flushTimer = setTimeout(this.performAutoFlush, interval);
+            // Let the event loop exit if this is the only active timer.
+            if (this.flushTimer.unref) this.flushTimer.unref();
+        }
+    }
+
+    /** @private */
+    async handleProcessExit() {
+        logDebug('Auto-flushing before process exits...');
+        this.flush();
     }
 }
 

--- a/lib/loggers.js
+++ b/lib/loggers.js
@@ -103,6 +103,53 @@ class BufferedMetricsLogger {
             opts.site = opts.site || opts.apiHost;
         }
 
+        let flushIntervalSeconds = 0;
+        let flushTimer = null;
+
+        const autoFlushCallback = () => {
+            this.flush();
+            if (this.flushIntervalSeconds) {
+                const interval = this.flushIntervalSeconds * 1000;
+                flushTimer = setTimeout(autoFlushCallback, interval);
+                // Let the event loop exit if this is the only active timer.
+                if (flushTimer.unref) flushTimer.unref();
+            }
+        };
+
+        const exitHandler = () => {
+            logDebug('Auto-flushing before process exits...');
+            this.flush();
+        };
+
+        Object.defineProperty(this, 'flushIntervalSeconds', {
+            get() { return flushIntervalSeconds; },
+            set(value) {
+                if (value < 0) {
+                    throw new TypeError(`flushIntervalSeconds must be >= 0 (got: ${value})`);
+                }
+
+                flushIntervalSeconds = value;
+
+                // TODO: if autoflushing was already happening, the next auto-
+                // flush should ideally happen N seconds after the last auto-
+                // flush, not N seconds from now.
+                clearTimeout(flushTimer);
+                if (flushIntervalSeconds > 0) {
+                    logDebug('Auto-flushing every %d seconds', flushIntervalSeconds);
+                    autoFlushCallback();
+                } else {
+                    logDebug('Auto-flushing is disabled');
+                }
+
+                if (typeof process !== 'undefined' && typeof process.once === 'function') {
+                    process.off('beforeExit', exitHandler);
+                    if (flushIntervalSeconds > 0) {
+                        process.once('beforeExit', exitHandler);
+                    }
+                }
+            }
+        });
+
         /** @private */
         this.aggregator = opts.aggregator || new Aggregator(opts.defaultTags);
         /** @private @type {ReporterType} */
@@ -127,24 +174,6 @@ class BufferedMetricsLogger {
         } else if (opts.onError != null) {
             throw new TypeError('The `onError` option must be a function');
         }
-
-        if (this.flushIntervalSeconds) {
-            logDebug('Auto-flushing every %d seconds', this.flushIntervalSeconds);
-        } else {
-            logDebug('Auto-flushing is disabled');
-        }
-
-        const autoFlushCallback = () => {
-            this.flush();
-            if (this.flushIntervalSeconds) {
-                const interval = this.flushIntervalSeconds * 1000;
-                const tid = setTimeout(autoFlushCallback, interval);
-                // Let the event loop exit if this is the only active timer.
-                if (tid.unref) tid.unref();
-            }
-        };
-
-        autoFlushCallback();
     }
 
     /**
@@ -325,6 +354,20 @@ class BufferedMetricsLogger {
         });
 
         return result;
+    }
+
+    /**
+     * Shut down the metrics logger. This will flush any buffered metrics and
+     * disable future auto-flushing.
+     * @param {Object} [options]
+     * @param {boolean} [options.flush=true] Whether to flush before returning.
+     *        Defaults to true.
+     */
+    async close({ flush = true } = {}) {
+        this.flushIntervalSeconds = 0;
+        if (flush) {
+            await this.flush();
+        }
     }
 }
 

--- a/test-other/types_check.ts
+++ b/test-other/types_check.ts
@@ -4,7 +4,7 @@ import {
     reporters,
     init,
     flush,
-    close,
+    stop,
     gauge,
     increment,
     histogram,
@@ -18,8 +18,8 @@ function useLogger(logger: BufferedMetricsLogger) {
     logger.histogram('histogram.key', 11);
     logger.distribution('distribution.key', 11);
     logger.flush();
-    logger.close();
-    logger.close({ flush: false });
+    logger.stop();
+    logger.stop({ flush: false });
 }
 
 useLogger(new BufferedMetricsLogger());
@@ -54,5 +54,5 @@ increment('increment.key');
 histogram('histogram.key', 11);
 distribution('distribution.key', 11);
 flush();
-close();
-close({ flush: false });
+stop();
+stop({ flush: false });

--- a/test-other/types_check.ts
+++ b/test-other/types_check.ts
@@ -4,6 +4,7 @@ import {
     reporters,
     init,
     flush,
+    close,
     gauge,
     increment,
     histogram,
@@ -17,6 +18,8 @@ function useLogger(logger: BufferedMetricsLogger) {
     logger.histogram('histogram.key', 11);
     logger.distribution('distribution.key', 11);
     logger.flush();
+    logger.close();
+    logger.close({ flush: false });
 }
 
 useLogger(new BufferedMetricsLogger());
@@ -51,3 +54,5 @@ increment('increment.key');
 histogram('histogram.key', 11);
 distribution('distribution.key', 11);
 flush();
+close();
+close({ flush: false });

--- a/test/loggers_tests.js
+++ b/test/loggers_tests.js
@@ -315,7 +315,7 @@ describe('BufferedMetricsLogger', function() {
         });
     });
 
-    describe('close()', function () {
+    describe('stop()', function () {
         beforeEach(function () {
             // FIXME: Should make a standard MockReporter to be used in all
             // tests that need to spy on what gets reported. See flush tests
@@ -337,18 +337,18 @@ describe('BufferedMetricsLogger', function() {
 
         it('flushes by default', async function () {
             this.reporter.calls.should.have.lengthOf(0);
-            await this.logger.close();
+            await this.logger.stop();
             this.reporter.calls.should.have.lengthOf(1);
         });
 
         it('does not flush if `flush: false`', async function () {
             this.reporter.calls.should.have.lengthOf(0);
-            await this.logger.close({ flush: false });
+            await this.logger.stop({ flush: false });
             this.reporter.calls.should.have.lengthOf(0);
         });
 
         it('stops auto-flushing', async function () {
-            await this.logger.close({ flush: false });
+            await this.logger.stop({ flush: false });
             this.reporter.calls.should.have.lengthOf(0);
 
             await new Promise(r => setTimeout(r, 125));
@@ -356,7 +356,7 @@ describe('BufferedMetricsLogger', function() {
         });
 
         it('stops auto-flushing on exit', async function () {
-            await this.logger.close({ flush: false });
+            await this.logger.stop({ flush: false });
             this.reporter.calls.should.have.lengthOf(0);
 
             process.emit('beforeExit', 0);

--- a/test/module_tests.js
+++ b/test/module_tests.js
@@ -16,7 +16,7 @@ beforeEach(function() {
 });
 
 afterEach(async function() {
-    await metrics.close({ flush: false });
+    await metrics.stop({ flush: false });
 });
 
 describe('datadog-metrics', function() {

--- a/test/module_tests.js
+++ b/test/module_tests.js
@@ -1,16 +1,22 @@
 'use strict';
 
 const chai = require('chai');
+const reporters = require('../lib/reporters.js');
+
 chai.should();
 
+/** @type {import("..") DotadogMetrics} */
 let metrics = null;
-const reporters = require('../lib/reporters.js');
 
 // Force-reload the module before every test so we
 // can realistically test all the scenarios.
 beforeEach(function() {
     delete require.cache[require.resolve('../index.js')];
     metrics = require('../index.js');
+});
+
+afterEach(async function() {
+    await metrics.close({ flush: false });
 });
 
 describe('datadog-metrics', function() {

--- a/test/reporters_tests.js
+++ b/test/reporters_tests.js
@@ -3,9 +3,11 @@
 const chai = require('chai');
 const nock = require('nock');
 
-chai.should();
 const { DatadogReporter, NullReporter } = require('../lib/reporters');
 const { AuthorizationError } = require('../lib/errors');
+
+chai.use(require('chai-as-promised'));
+chai.should();
 
 const mockMetric = {
     metric: 'test.gauge',


### PR DESCRIPTION
~**This is a bit of an ugly first pass.** The code needs some cleanup and there are some open questions, but it works and has docs and tests.~ Fixes #136.

This attaches to the process’s `beforeExit` event (supported in Node.js, Deno, and Bun) when auto-flushing is enabled in order to automatically flush when a program exits. Before, you needed to remember to call `metrics.flush()` manually at the end of your program, which is easy to forget (or not even know about in the first place!).

It also adds a `close()` method (not sure about the name) that flushes and buffered metrics and disables auto-flushing. It does *not* prevent adding new metrics to the buffer, but maybe it should? (Would they error? Get dropped silently? Call the `onError` handler?)

**To-do/open questions:**

- [x] Clean up implementation. At the very least, get some of this code out of the `BufferedMetricsLogger` constructor.
- [x] Dedupe all the mock reporter code in tests.
- [x] Is `close()` a good name? Other ideas: *(Update: renamed to `stop`)*
    - `stop()`
    - `shutdown()`
    - `destroy()`
    - `disable()`
    - `pause()`
- [x] Should `close()` also prevent buffering new metrics? (i.e. make `addPoint()` a no-op, or maybe throw an exception or call the global error handler) *(Update: decided no for now.)*