### PR TITLE
Drop the official Datadog client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # Test supported release Node.js versions (even numbers) plus current
         # development version.
-        node_version: [12, 14, 16, 18, 20, 22, 23]
+        node_version: [14, 16, 18, 20, 22, 24]
 
     steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ For changes to this repo, follow the [local development](#local-development) ste
 
 1. If you don't have commit rights to this repo, [fork it][fork].
 
-2. Install Node.js 12 or newer.
+2. Install Node.js 14 or newer.
 
 3. Clone your fork (or this repo if you have commit rights) to your local development machine:
 

--- a/README.md
+++ b/README.md
@@ -371,7 +371,9 @@ Contributions are always welcome! For more info on how to contribute or develop 
 
 **Breaking Changes:**
 
-* The minimum required Node.js version is now 14.0.0.
+* The minimum required Node.js version is now v14.0.0.
+
+* The `code` property on `AuthorizationError` instances has been changed to `DATADOG_METRICS_AUTHORIZATION_ERROR` to make names more clear and consistent (it was previously `DATADOG_AUTHORIZATION_ERROR`). If you are using `errorInstance.code` to check types, make sure to update the string you are looking for.
 
 **New Features:**
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The downside of using the HTTP API is that it can negatively affect your app's p
 
 ## Installation
 
-Datadog-metrics is compatible with Node.js v12 and later. You can install it with NPM:
+Datadog-metrics is compatible with Node.js v14 and later. You can install it with NPM:
 
 ```sh
 npm install datadog-metrics --save
@@ -371,7 +371,7 @@ Contributions are always welcome! For more info on how to contribute or develop 
 
 **Breaking Changes:**
 
-TBD
+* The minimum required Node.js version is now 14.0.0.
 
 **New Features:**
 
@@ -387,7 +387,7 @@ TBD
 
 **Maintenance:**
 
-TBD
+* Under the hood, we’ve removed a dependency on the official Datadog client (`@datadog/datadog-api-client`). This is an attempt to streamline the package, since the official client comes at a sizeable 15 MB of code for you to download and then load in your application. (#144)
 
 [View diff](https://github.com/dbader/node-datadog-metrics/compare/v0.12.1...main)
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -2,7 +2,7 @@
 
 /**
  * Base class for errors from datadog-metrics.
- * @property {'DATADOG_AUTHORIZATION_ERROR'} code
+ * @property {'DATADOG_METRICS_ERROR'} code
  */
 class DatadogMetricsError extends Error {
     constructor(message, options = {}) {
@@ -15,15 +15,14 @@ class DatadogMetricsError extends Error {
 }
 
 /**
- * Represents an authorization failure response from the Datadog API, usually
- * because of an invalid API key.
+ * Represents an HTTP error response from the Datadog API.
  *
- * @property {'DATADOG_HTTP_ERROR'} code
+ * @property {'DATADOG_METRICS_HTTP_ERROR'} code
  * @property {number} status The HTTP status code.
  */
-class MetricsHttpError extends DatadogMetricsError {
+class HttpError extends DatadogMetricsError {
     /**
-     * Create a `MetricsHttpError`.
+     * Create a `HttpError`.
      * @param {string} message
      * @param {object} options
      * @param {any} options.response
@@ -32,7 +31,7 @@ class MetricsHttpError extends DatadogMetricsError {
      */
     constructor (message, options) {
         super(message, { cause: options.cause });
-        this.code = 'DATADOG_HTTP_ERROR';
+        this.code = 'DATADOG_METRICS_HTTP_ERROR';
         this.response = options.response;
         this.body = options.body;
         this.status = this.response.status;
@@ -43,7 +42,7 @@ class MetricsHttpError extends DatadogMetricsError {
  * Represents an authorization failure response from the Datadog API, usually
  * because of an invalid API key.
  *
- * @property {'DATADOG_AUTHORIZATION_ERROR'} code
+ * @property {'DATADOG_METRICS_AUTHORIZATION_ERROR'} code
  * @property {number} status
  */
 class AuthorizationError extends DatadogMetricsError {
@@ -55,13 +54,13 @@ class AuthorizationError extends DatadogMetricsError {
      */
     constructor(message, options = {}) {
         super(message, { cause: options.cause });
-        this.code = 'DATADOG_AUTHORIZATION_ERROR';
+        this.code = 'DATADOG_METRICS_AUTHORIZATION_ERROR';
         this.status = 403;
     }
 }
 
 module.exports = {
     DatadogMetricsError,
-    MetricsHttpError,
+    HttpError,
     AuthorizationError
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,13 +1,52 @@
 'use strict';
 
 /**
+ * Base class for errors from datadog-metrics.
+ * @property {'DATADOG_AUTHORIZATION_ERROR'} code
+ */
+class DatadogMetricsError extends Error {
+    constructor(message, options = {}) {
+        // @ts-expect-error the ECMAScript version we target with TypeScript
+        // does not include `error.cause` (new in ES 2022), but all versions of
+        // Node.js we support do.
+        super(message, { cause: options.cause });
+        this.code = 'DATADOG_METRICS_ERROR';
+    }
+}
+
+/**
+ * Represents an authorization failure response from the Datadog API, usually
+ * because of an invalid API key.
+ *
+ * @property {'DATADOG_HTTP_ERROR'} code
+ * @property {number} status The HTTP status code.
+ */
+class MetricsHttpError extends DatadogMetricsError {
+    /**
+     * Create a `MetricsHttpError`.
+     * @param {string} message
+     * @param {object} options
+     * @param {any} options.response
+     * @param {any} [options.body]
+     * @param {Error} [options.cause]
+     */
+    constructor (message, options) {
+        super(message, { cause: options.cause });
+        this.code = 'DATADOG_HTTP_ERROR';
+        this.response = options.response;
+        this.body = options.body;
+        this.status = this.response.status;
+    }
+}
+
+/**
  * Represents an authorization failure response from the Datadog API, usually
  * because of an invalid API key.
  *
  * @property {'DATADOG_AUTHORIZATION_ERROR'} code
  * @property {number} status
  */
-class AuthorizationError extends Error {
+class AuthorizationError extends DatadogMetricsError {
     /**
      * Create an `AuthorizationError`.
      * @param {string} message
@@ -15,13 +54,14 @@ class AuthorizationError extends Error {
      * @param {Error} [options.cause]
      */
     constructor(message, options = {}) {
-        // @ts-expect-error the ECMAScript version we target with TypeScript
-        // does not include `error.cause` (new in ES 2022), but all versions of
-        // Node.js we support do.
         super(message, { cause: options.cause });
         this.code = 'DATADOG_AUTHORIZATION_ERROR';
         this.status = 403;
     }
 }
 
-module.exports = { AuthorizationError };
+module.exports = {
+    DatadogMetricsError,
+    MetricsHttpError,
+    AuthorizationError
+};

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -1,6 +1,6 @@
 'use strict';
 const { fetch } = require('cross-fetch');
-const { AuthorizationError, MetricsHttpError } = require('./errors');
+const { AuthorizationError, DatadogMetricsError, HttpError } = require('./errors');
 const { logDebug, logDeprecation } = require('./logging');
 
 const RETRYABLE_ERROR_CODES = new Set([
@@ -55,7 +55,7 @@ class HttpApi {
                     if (body && body.errors) {
                         message += ` (${body.errors.join(', ')})`;
                     }
-                    throw new MetricsHttpError(message, { response });
+                    throw new HttpError(message, { response });
                 }
                 return body;
             } else {
@@ -143,7 +143,7 @@ class DatadogReporter {
         const apiKey = options.apiKey || process.env.DATADOG_API_KEY || process.env.DD_API_KEY;
 
         if (!apiKey) {
-            throw new Error(
+            throw new DatadogMetricsError(
                 'Datadog API key not found. You must specify one via the ' +
                 '`apiKey` configuration option or the DATADOG_API_KEY or ' +
                 'DD_API_KEY environment variable.'

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -41,24 +41,35 @@ class HttpApi {
         while (true) {  // eslint-disable-line no-constant-condition
             let response, body, error;
             try {
+                logDebug(`Sending HTTP request to "${url}"`);
                 response = await fetch(url, options);
                 body = await response.json();
             } catch (e) {
                 error = e;
             }
 
+            const details = this.getLogDetails(url, response, error);
             if (this.isRetryable(response || error, i)) {
-                await sleep(this.retryDelay(response || error, i));
+                const delay = this.retryDelay(response || error, i);
+                logDebug(`HTTP request failed, retrying in ${delay} ms. ${details}`);
+
+                await sleep(delay);
             } else if (response) {
                 if (response.status >= 400) {
+                    logDebug(`HTTP request failed. ${details}`);
+
                     let message = `Could not fetch ${url}`;
                     if (body && body.errors) {
                         message += ` (${body.errors.join(', ')})`;
                     }
                     throw new HttpError(message, { response });
                 }
+
+                logDebug(`HTTP request succeeded. ${details}`);
                 return body;
             } else {
+                logDebug(`HTTP request failed. ${details}`);
+
                 throw error;
             }
 
@@ -103,6 +114,17 @@ class HttpApi {
         }
 
         return this.backoffMultiplier ** tryCount * this.backoffBase * 1000;
+    }
+
+    /**
+     * @private
+     * @param {string} url
+     * @param {Response?} response
+     * @param {Error?} error
+     */
+    getLogDetails(url, response, error) {
+        let result = response ? `HTTP status: ${response.status}` : `error: ${error}`;
+        return `URL: "${url}", ${result}`;
     }
 }
 

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -1,6 +1,6 @@
 'use strict';
-const datadogApiClient = require('@datadog/datadog-api-client');
-const { AuthorizationError } = require('./errors');
+const { fetch } = require('cross-fetch');
+const { AuthorizationError, MetricsHttpError } = require('./errors');
 const { logDebug, logDeprecation } = require('./logging');
 
 const RETRYABLE_ERROR_CODES = new Set([
@@ -27,30 +27,22 @@ class NullReporter {
 
 /**
  * @private
- * A custom HTTP implementation for Datadog that retries failed requests.
- * Datadog has retries built in, but they don't handle network errors (just
- * HTTP errors), and we want to retry in both cases. This inherits from the
- * built-in HTTP library since we want to use the same fetch implementation
- * Datadog uses instead of adding another dependency.
+ * Manages HTTP requests and associated retry/error handling logic.
  */
-class RetryHttp extends datadogApiClient.client.IsomorphicFetchHttpLibrary {
-    constructor(options = {}) {
-        super(options);
-
-        // HACK: ensure enableRetry is always `false` so the base class logic
-        // does not actually retry (since we manage retries here).
-        Object.defineProperty(this, 'enableRetry', {
-            get () { return false; },
-            set () {},
-        });
+class HttpApi {
+    constructor(options) {
+        this.maxRetries = options.maxRetries;
+        this.backoffBase = options.backoffBase;
+        this.backoffMultiplier = 2;
     }
 
-    async send(request) {
+    async send(url, options) {
         let i = 0;
         while (true) {  // eslint-disable-line no-constant-condition
-            let response, error;
+            let response, body, error;
             try {
-                response = await super.send(request);
+                response = await fetch(url, options);
+                body = await response.json();
             } catch (e) {
                 error = e;
             }
@@ -58,7 +50,14 @@ class RetryHttp extends datadogApiClient.client.IsomorphicFetchHttpLibrary {
             if (this.isRetryable(response || error, i)) {
                 await sleep(this.retryDelay(response || error, i));
             } else if (response) {
-                return response;
+                if (response.status >= 400) {
+                    let message = `Could not fetch ${url}`;
+                    if (body && body.errors) {
+                        message += ` (${body.errors.join(', ')})`;
+                    }
+                    throw new MetricsHttpError(message, { response });
+                }
+                return body;
             } else {
                 throw error;
             }
@@ -75,8 +74,8 @@ class RetryHttp extends datadogApiClient.client.IsomorphicFetchHttpLibrary {
     isRetryable(response, tryCount) {
         return tryCount < this.maxRetries && (
             RETRYABLE_ERROR_CODES.has(response.code)
-            || response.httpStatusCode === 429
-            || response.httpStatusCode >= 500
+            || response.status === 429
+            || response.status >= 500
         );
     }
 
@@ -87,7 +86,7 @@ class RetryHttp extends datadogApiClient.client.IsomorphicFetchHttpLibrary {
      * @returns {number}
      */
     retryDelay(response, tryCount) {
-        if (response.httpStatusCode === 429) {
+        if (response.status === 429) {
             // Datadog's official client supports just the 'x-ratelimit-reset'
             // header, so we support that here in addition to the standardized
             // 'retry-after' heaer.
@@ -95,8 +94,8 @@ class RetryHttp extends datadogApiClient.client.IsomorphicFetchHttpLibrary {
             // has moved away from the syntax used in 'x-ratelimit-reset'. This
             // stuff might change in the future.
             // https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/
-            const delayHeader = response.headers['retry-after']
-                || response.headers['x-ratelimit-reset'];
+            const delayHeader = response.headers.get('retry-after')
+                || response.headers.get('x-ratelimit-reset');
             const delayValue = parseInt(delayHeader, 10);
             if (!isNaN(delayValue) && delayValue > 0) {
                 return delayValue * 1000;
@@ -117,8 +116,8 @@ class RetryHttp extends datadogApiClient.client.IsomorphicFetchHttpLibrary {
  *           wait this long multiplied by 2^(retry count).
  */
 
-/** @type {WeakMap<DatadogReporter, datadogApiClient.v1.MetricsApi>} */
-const datadogClients = new WeakMap();
+/** @type {WeakMap<DatadogReporter, string>} */
+const datadogApiKeys = new WeakMap();
 
 /**
  * Create a reporter that sends metrics to Datadog's API.
@@ -142,10 +141,6 @@ class DatadogReporter {
         }
 
         const apiKey = options.apiKey || process.env.DATADOG_API_KEY || process.env.DD_API_KEY;
-        this.site = options.site
-            || process.env.DATADOG_SITE
-            || process.env.DD_SITE
-            || process.env.DATADOG_API_HOST;
 
         if (!apiKey) {
             throw new Error(
@@ -155,30 +150,25 @@ class DatadogReporter {
             );
         }
 
-        const configuration = datadogApiClient.client.createConfiguration({
-            authMethods: {
-                apiKeyAuth: apiKey,
-            },
-            httpApi: new RetryHttp(),
+        /** @private @type {HttpApi} */
+        this.httpApi = new HttpApi({
             maxRetries: options.retries >= 0 ? options.retries : 2,
+            retryBackoff: options.retryBackoff >= 0 ? options.retryBackoff : 1
         });
 
-        // HACK: Specify backoff here rather than in configration options to
-        // support values less than 2 (mainly for faster tests).
-        const backoff = options.retryBackoff >= 0 ? options.retryBackoff : 1;
-        configuration.httpApi.backoffBase = backoff;
+        /** @private @type {string} */
+        this.site = options.site
+            || process.env.DATADOG_SITE
+            || process.env.DD_SITE
+            || process.env.DATADOG_API_HOST
+            || 'datadoghq.com';
 
-        if (this.site) {
-            // Strip leading `app.` from the site in case someone copy/pasted the
-            // URL from their web browser. More details on correct configuration:
-            // https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
-            this.site = this.site.replace(/^app\./i, '');
-            configuration.setServerVariables({
-                site: this.site
-            });
-        }
+        // Strip leading `app.` from the site in case someone copy/pasted the
+        // URL from their web browser. More details on correct configuration:
+        // https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
+        this.site = this.site.replace(/^app\./i, '');
 
-        datadogClients.set(this, new datadogApiClient.v1.MetricsApi(configuration));
+        datadogApiKeys.set(this, apiKey);
     }
 
     /**
@@ -201,25 +191,19 @@ class DatadogReporter {
             }
         }
 
-        const metricsApi = datadogClients.get(this);
-
         let submissions = [];
         if (metrics.length) {
-            submissions.push(metricsApi.submitMetrics({
-                body: { series: metrics }
-            }));
+            submissions.push(this.sendMetrics(metrics));
         }
         if (distributions.length) {
-            submissions.push(metricsApi.submitDistributionPoints({
-                body: { series: distributions }
-            }));
+            submissions.push(this.sendDistributions(distributions));
         }
 
         try {
             await Promise.all(submissions);
             logDebug('sent metrics successfully');
         } catch (error) {
-            if (error.code === 403) {
+            if (error.status === 403) {
                 throw new AuthorizationError(
                     'Your Datadog API key is not authorized to send ' +
                     'metrics. Check to make sure the DATADOG_API_KEY or ' +
@@ -234,6 +218,45 @@ class DatadogReporter {
 
             throw error;
         }
+    }
+
+    /**
+     * Send an array of metrics to the Datadog API.
+     * @private
+     * @param {any[]} series
+     * @returns {Promise}
+     */
+    sendMetrics(series) {
+        return this.sendHttp('/v1/series', { body: { series } });
+    }
+
+    /**
+     * Send an array of distributions to the Datadog API.
+     * @private
+     * @param {any[]} series
+     * @returns {Promise}
+     */
+    sendDistributions(series) {
+        return this.sendHttp('/v1/distribution_points', { body: { series } });
+    }
+
+    /**
+     * @private
+     * @param {string} path
+     * @param {any} options
+     * @returns {Promise}
+     */
+    async sendHttp(path, options) {
+        const url = `https://api.${this.site}/api${path}`;
+        const fetchOptions = {
+            method: 'POST',
+            headers: {
+                'DD-API-KEY': datadogApiKeys.get(this),
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(options.body)
+        };
+        return await this.httpApi.send(url, fetchOptions);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "devDependencies": {
     "@datadog/datadog-api-client": "^1.31.0",
-    "@types/node": "^12.20.55",
+    "@types/node": "^14.14.45",
     "chai": "4.3.6",
     "chai-as-promised": "^7.1.2",
     "chai-string": "1.5.0",
@@ -40,11 +40,11 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "cross-fetch": "^3.2.0",
+    "cross-fetch": "^4.0.0",
     "debug": "^4.1.0"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "files": [
     "README.md",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "author": "Daniel Bader <mail@dbader.org> (http://dbader.org/)",
   "license": "MIT",
   "devDependencies": {
+    "@datadog/datadog-api-client": "^1.31.0",
     "@types/node": "^12.20.55",
     "chai": "4.3.6",
     "chai-as-promised": "^7.1.2",
@@ -39,7 +40,7 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "^1.17.0",
+    "cross-fetch": "^3.2.0",
     "debug": "^4.1.0"
   },
   "engines": {

--- a/test/reporters_tests.js
+++ b/test/reporters_tests.js
@@ -23,17 +23,23 @@ describe('NullReporter', function() {
 });
 
 describe('DatadogReporter', function() {
-    afterEach(() => {
+    let originalEnv = Object.entries(process.env)
+        .filter(([key, _]) => !/^(DD|DATADOG)_/.test(key));
+
+    before(() => {
+        nock.disableNetConnect();
+    });
+
+    after(() => {
+        nock.enableNetConnect();
+    });
+
+    beforeEach(() => {
         nock.cleanAll();
+        process.env = Object.fromEntries(originalEnv);
     });
 
     describe('constructor', function() {
-        let originalEnv = Object.entries(process.env);
-
-        afterEach(() => {
-            process.env = Object.fromEntries(originalEnv);
-        });
-
         it('creates a DatadogReporter', () => {
             const instance = new DatadogReporter({
                 apiKey: 'abc',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
-        "lib": ["es2019"],
-        "target": "es2019",
+        "lib": ["es2020"],
+        "target": "es2020",
 
         "module": "commonjs",
         "esModuleInterop": true,


### PR DESCRIPTION
**This is a first pass, and is a bit speculative.** This PR drops the official Datadog client as a runtime dependency since it is *huge* (15 MB!) and imposes a lot of runtime costs and some logging confusion (e.g. #133).

The implementation here basically swaps out `@datadog/datadog-api-client` for `cross-fetch`, which is what `@datadog/datadog-api-client` was using, so the potential issues should be pretty minimal here.

I was hoping to fix the punycode deprecation warning, but was not able to do so because the dependencies causing the issue require newer versions of Node.js than we currently do (Node.js 12.0). We can upgrade `cross-fetch` (requires Node.js 14.0) or switch directly to `node-fetch` (requires Node.js 12.20, but cuts off the tacit-but-not-guaranteed-compatibility we have with React Native and with Browsers). Either one of these is probably OK (Node.js maintenance only extends back to v18 these days anyway, and our biggest dependee, datadog-ci, only requires Node.js 14). Something to think through before landing this.