### PR TITLE
Formally declare Deno & Bun compatibility

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,6 +48,13 @@
             "rules": {
                 "max-statements": ["off"]
             }
+        },
+        {
+            "files": ["**/*.mjs"],
+            "parserOptions": {
+                "ecmaVersion": 2019,
+                "sourceType": "module"
+            }
         }
       ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           deno-version: '~2.0'
+
+      - name: Install dependencies
+        run: deno install
+
       - name: Check Integration
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,24 @@ jobs:
         run: |
           npm run check-integration
 
+  test-deno-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: '~2.0'
+      - name: Check Integration
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY }}
+          DATADOG_SITE: ${{ secrets.DATADOG_API_HOST }}
+        run: |
+          cd test-other
+          deno --allow-all integration_check_deno.ts
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,7 @@ jobs:
           DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY }}
           DATADOG_SITE: ${{ secrets.DATADOG_API_HOST }}
         run: |
-          cd test-other
-          deno --allow-all integration_check_deno.ts
+          deno --allow-all test-other/integration_check_deno.ts
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,27 @@ jobs:
         run: |
           deno --allow-all test-other/integration_check_deno.ts
 
+  test-bun-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.0.36'
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Check Integration
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY }}
+          DATADOG_SITE: ${{ secrets.DATADOG_API_HOST }}
+        run: |
+          bun test-other/integration_check.mjs '-bun'
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: '~2.0'
+          deno-version: '~2.1'
 
       - name: Install dependencies
         run: deno install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.0.36'
+          bun-version: '1.0.x'
 
       - name: Install dependencies
         run: bun install
@@ -98,7 +98,7 @@ jobs:
           DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY }}
           DATADOG_SITE: ${{ secrets.DATADOG_API_HOST }}
         run: |
-          bun test-other/integration_check.mjs '-bun'
+          bun test-other/integration_check.mjs bun
 
   lint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -800,4 +800,4 @@ Your contributions are always welcome! See [`CONTRIBUTING.md`](./CONTRIBUTING.md
 [npm-downloads]: https://img.shields.io/npm/dm/datadog-metrics.svg?style=flat-square
 [ci-status-image]: https://github.com/dbader/node-datadog-metrics/actions/workflows/ci.yml/badge.svg?branch=main
 [ci-status-url]: https://github.com/dbader/node-datadog-metrics/actions/workflows/ci.yml?query=branch%3Amain
-[deno-image]: https://shield.deno.dev/deno/2.1
+[deno-image]: https://shield.deno.dev/deno/^2.1

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![NPM Version][npm-image]][npm-url]
 [![Build Status][ci-status-image]][ci-status-url]
 [![Downloads Stats][npm-downloads]][npm-url]
+![deno compatibility][deno-image]
 
 Datadog-metrics lets you collect application metrics through Datadog's HTTP API. Using the HTTP API has the benefit that you **don't need to install the Datadog Agent (StatsD)**. Just get an API key, install the module and you're ready to go.
 
@@ -11,7 +12,7 @@ The downside of using the HTTP API is that it can negatively affect your app's p
 
 ## Installation
 
-Datadog-metrics is compatible with Node.js v14 and later. You can install it with NPM:
+Datadog-metrics is compatible with Node.js v14 and later and Deno 2.0 and later. You can install it with NPM:
 
 ```sh
 npm install datadog-metrics --save
@@ -371,13 +372,13 @@ Contributions are always welcome! For more info on how to contribute or develop 
 
 **Breaking Changes:**
 
-* The minimum required Node.js version is now v14.0.0.
+* The minimum required Node.js version is now v14.0.0 and Deno version is 2.0.0.
 
 * The `code` property on `AuthorizationError` instances has been changed to `DATADOG_METRICS_AUTHORIZATION_ERROR` for clarity and consistency (it was previously `DATADOG_AUTHORIZATION_ERROR`). If you are using `errorInstance.code` to check types, make sure to update the string you were looking for.
 
 **New Features:**
 
-TBD
+* Clarify this package is compatible with Deno (>= v2.0). We’ve silently worked on Deno for a long time, but never formally supported it before this release.
 
 **Deprecations:**
 
@@ -799,3 +800,4 @@ Your contributions are always welcome! See [`CONTRIBUTING.md`](./CONTRIBUTING.md
 [npm-downloads]: https://img.shields.io/npm/dm/datadog-metrics.svg?style=flat-square
 [ci-status-image]: https://github.com/dbader/node-datadog-metrics/actions/workflows/ci.yml/badge.svg?branch=main
 [ci-status-url]: https://github.com/dbader/node-datadog-metrics/actions/workflows/ci.yml?query=branch%3Amain
+[deno-image]: https://shield.deno.dev/deno/2.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The downside of using the HTTP API is that it can negatively affect your app's p
 
 ## Installation
 
-Datadog-metrics is compatible with Node.js v14 and later and Deno 2.0 and later. You can install it with NPM:
+Datadog-metrics is compatible with Node.js v14 and later and Deno 2.1 and later. You can install it with NPM:
 
 ```sh
 npm install datadog-metrics --save
@@ -372,13 +372,13 @@ Contributions are always welcome! For more info on how to contribute or develop 
 
 **Breaking Changes:**
 
-* The minimum required Node.js version is now v14.0.0 and Deno version is 2.0.0.
+* The minimum required Node.js version is now v14.0.0 and Deno version is 2.1.0.
 
 * The `code` property on `AuthorizationError` instances has been changed to `DATADOG_METRICS_AUTHORIZATION_ERROR` for clarity and consistency (it was previously `DATADOG_AUTHORIZATION_ERROR`). If you are using `errorInstance.code` to check types, make sure to update the string you were looking for.
 
 **New Features:**
 
-* Clarify this package is compatible with Deno (>= v2.0). We’ve silently worked on Deno for a long time, but never formally supported it before this release.
+* Clarify this package is compatible with Deno (>= v2.1). We’ve silently worked on Deno for a long time, but never formally supported it before this release.
 
 **Deprecations:**
 
@@ -800,4 +800,4 @@ Your contributions are always welcome! See [`CONTRIBUTING.md`](./CONTRIBUTING.md
 [npm-downloads]: https://img.shields.io/npm/dm/datadog-metrics.svg?style=flat-square
 [ci-status-image]: https://github.com/dbader/node-datadog-metrics/actions/workflows/ci.yml/badge.svg?branch=main
 [ci-status-url]: https://github.com/dbader/node-datadog-metrics/actions/workflows/ci.yml?query=branch%3Amain
-[deno-image]: https://shield.deno.dev/deno/2.0
+[deno-image]: https://shield.deno.dev/deno/2.1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![NPM Version][npm-image]][npm-url]
 [![Build Status][ci-status-image]][ci-status-url]
 [![Downloads Stats][npm-downloads]][npm-url]
-![deno compatibility][deno-image]
+![Supports Deno 2.1 and Newer][deno-image]
+![Supports Bun 1.0 and Newer][bun-image]
 
 Datadog-metrics lets you collect application metrics through Datadog's HTTP API. Using the HTTP API has the benefit that you **don't need to install the Datadog Agent (StatsD)**. Just get an API key, install the module and you're ready to go.
 
@@ -12,7 +13,7 @@ The downside of using the HTTP API is that it can negatively affect your app's p
 
 ## Installation
 
-Datadog-metrics is compatible with Node.js v14 and later and Deno 2.1 and later. You can install it with NPM:
+Datadog-metrics is compatible with Node.js v14+, Deno 2.1+, and Bun 1.0+. You can install it with NPM:
 
 ```sh
 npm install datadog-metrics --save
@@ -372,13 +373,13 @@ Contributions are always welcome! For more info on how to contribute or develop 
 
 **Breaking Changes:**
 
-* The minimum required Node.js version is now v14.0.0 and Deno version is 2.1.0.
+* The minimum required Node.js version is now v14.0.0, Deno version is 2.1.0, and Bun version is 1.0.0.
 
 * The `code` property on `AuthorizationError` instances has been changed to `DATADOG_METRICS_AUTHORIZATION_ERROR` for clarity and consistency (it was previously `DATADOG_AUTHORIZATION_ERROR`). If you are using `errorInstance.code` to check types, make sure to update the string you were looking for.
 
 **New Features:**
 
-* Clarify this package is compatible with Deno (>= v2.1). We’ve silently worked on Deno for a long time, but never formally supported it before this release.
+* Clarify this package is compatible with Deno (>= v2.1) and Bun (>= 1.0). We’ve silently worked on Deno and Bun for a long time, but never formally supported them before this release.
 
 **Deprecations:**
 
@@ -800,4 +801,5 @@ Your contributions are always welcome! See [`CONTRIBUTING.md`](./CONTRIBUTING.md
 [npm-downloads]: https://img.shields.io/npm/dm/datadog-metrics.svg?style=flat-square
 [ci-status-image]: https://github.com/dbader/node-datadog-metrics/actions/workflows/ci.yml/badge.svg?branch=main
 [ci-status-url]: https://github.com/dbader/node-datadog-metrics/actions/workflows/ci.yml?query=branch%3Amain
-[deno-image]: https://shield.deno.dev/deno/^2.1
+[deno-image]: https://img.shields.io/badge/Deno-^2.1-blue?logo=deno&color=70ffaf&logoColor=ffffff
+[bun-image]: https://img.shields.io/badge/Bun-^1.0-blue?logo=bun&color=f368e0

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![NPM Version][npm-image]][npm-url]
 [![Build Status][ci-status-image]][ci-status-url]
 [![Downloads Stats][npm-downloads]][npm-url]
+![Supports all Node LTS versions][node-image]
 ![Supports Deno 2.1 and Newer][deno-image]
 ![Supports Bun 1.0 and Newer][bun-image]
 
@@ -801,5 +802,6 @@ Your contributions are always welcome! See [`CONTRIBUTING.md`](./CONTRIBUTING.md
 [npm-downloads]: https://img.shields.io/npm/dm/datadog-metrics.svg?style=flat-square
 [ci-status-image]: https://github.com/dbader/node-datadog-metrics/actions/workflows/ci.yml/badge.svg?branch=main
 [ci-status-url]: https://github.com/dbader/node-datadog-metrics/actions/workflows/ci.yml?query=branch%3Amain
+[node-image]: https://img.shields.io/node/v-lts/datadog-metrics/latest
 [deno-image]: https://img.shields.io/badge/Deno-^2.1-blue?logo=deno&color=70ffaf&logoColor=ffffff
 [bun-image]: https://img.shields.io/badge/Bun-^1.0-blue?logo=bun&color=f368e0

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "prepack": "npm run clean && npm run build-types && npm run check-types",
     "test": "mocha --reporter spec",
-    "check-integration": "node test-other/integration_check.js",
+    "check-integration": "node test-other/integration_check.mjs",
     "check-codestyle": "npx eslint .",
     "check-text": "test-other/lint_text.sh",
     "build-types": "tsc --build",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "datadog-metrics",
   "version": "0.13.0-dev",
   "description": "Buffered metrics reporting via the Datadog HTTP API",
+  "type": "commonjs",
   "main": "index.js",
   "types": "dist/index.d.ts",
   "repository": {

--- a/test-other/integration_check.mjs
+++ b/test-other/integration_check.mjs
@@ -1,0 +1,12 @@
+/**
+ * A basic test of our complete integration with Datadog. This check sends some
+ * metrics, then queries to make sure they actually got ingested correctly by
+ * Datadog and will show up as expected.
+ */
+
+import { main } from './integration_check_lib.mjs';
+
+main().catch(error => {
+    process.exitCode = 1;
+    console.error(error);
+});

--- a/test-other/integration_check.mjs
+++ b/test-other/integration_check.mjs
@@ -6,7 +6,7 @@
 
 import { main } from './integration_check_lib.mjs';
 
-main().catch(error => {
+main({ tagSuffix: process.argv[2] || '' }).catch(error => {
     process.exitCode = 1;
     console.error(error);
 });

--- a/test-other/integration_check_deno.ts
+++ b/test-other/integration_check_deno.ts
@@ -6,7 +6,7 @@
 
 import { main } from './integration_check_lib.mjs';
 
-main({ variant: 'deno' }).catch(error => {
+main({ tagSuffix: '-deno' }).catch(error => {
     process.exitCode = 1;
     console.error(error);
 });

--- a/test-other/integration_check_deno.ts
+++ b/test-other/integration_check_deno.ts
@@ -1,0 +1,12 @@
+/**
+ * A basic test of our complete integration with Datadog. This check sends some
+ * metrics, then queries to make sure they actually got ingested correctly by
+ * Datadog and will show up as expected.
+ */
+
+import { main } from './integration_check_lib.mjs';
+
+main({ variant: 'deno' }).catch(error => {
+    process.exitCode = 1;
+    console.error(error);
+});

--- a/test-other/integration_check_deno.ts
+++ b/test-other/integration_check_deno.ts
@@ -1,12 +1,11 @@
 /**
- * A basic test of our complete integration with Datadog. This check sends some
- * metrics, then queries to make sure they actually got ingested correctly by
- * Datadog and will show up as expected.
+ * Live integration test entrypoint for Deno. This is essentially the same as
+ * `integration_check.mjs` but is TypeScript for usage in Deno.
  */
 
 import { main } from './integration_check_lib.mjs';
 
-main({ tagSuffix: '-deno' }).catch(error => {
+main({ tagSuffix: 'deno' }).catch(error => {
     process.exitCode = 1;
     console.error(error);
 });

--- a/test-other/integration_check_lib.mjs
+++ b/test-other/integration_check_lib.mjs
@@ -44,7 +44,13 @@ const testMetrics = [
     },
 ];
 
-export async function main() {
+export async function main({ tagSuffix = '' } = {}) {
+    if (tagSuffix) {
+        for (const metric of testMetrics) {
+            metric.tags = metric.tags.map(tag => `${tag}${tagSuffix}`);
+        }
+    }
+
     datadogMetrics.init({ flushIntervalSeconds: 0 });
 
     for (const metric of testMetrics) {

--- a/test-other/integration_check_lib.mjs
+++ b/test-other/integration_check_lib.mjs
@@ -73,9 +73,7 @@ export async function sendMetric(metric) {
 
     for (const [timestamp, value] of testPoints) {
         datadogMetrics[metric.type](metric.name, value, metric.tags, timestamp);
-        await new Promise((resolve, reject) => {
-            datadogMetrics.flush(resolve, reject);
-        });
+        await datadogMetrics.flush();
     }
 }
 

--- a/test-other/integration_check_lib.mjs
+++ b/test-other/integration_check_lib.mjs
@@ -4,10 +4,8 @@
  * Datadog and will show up as expected.
  */
 
-'use strict';
-
-const { client, v1 } = require('@datadog/datadog-api-client');
-const datadogMetrics = require('..');
+import { client, v1 } from '@datadog/datadog-api-client';
+import datadogMetrics from '../index.js';
 
 function floorTo(value, points) {
     const factor = 10 ** points;
@@ -46,7 +44,7 @@ const testMetrics = [
     },
 ];
 
-async function main() {
+export async function main() {
     datadogMetrics.init({ flushIntervalSeconds: 0 });
 
     for (const metric of testMetrics) {
@@ -64,7 +62,7 @@ async function main() {
     }
 }
 
-async function sendMetric(metric) {
+export async function sendMetric(metric) {
     console.log(`Sending random points for ${metric.type} "${metric.name}"`);
 
     for (const [timestamp, value] of testPoints) {
@@ -75,7 +73,7 @@ async function sendMetric(metric) {
     }
 }
 
-async function queryMetric(metric) {
+export async function queryMetric(metric) {
     const configuration = client.createConfiguration({
         authMethods: {
             apiKeyAuth: process.env.DATADOG_API_KEY,
@@ -95,7 +93,7 @@ async function queryMetric(metric) {
     return data.series && data.series[0];
 }
 
-async function waitForSentMetric(metric) {
+export async function waitForSentMetric(metric) {
     const endTime = Date.now() + MAX_WAIT_TIME;
     while (Date.now() < endTime) {
         console.log(`Querying Datadog for sent points in ${metric.type} "${metric.name}"...`);
@@ -130,11 +128,4 @@ async function waitForSentMetric(metric) {
 
     console.log('✘ Nothing found and gave up waiting. Test failed!');
     return false;
-}
-
-if (require.main === module) {
-    main().catch(error => {
-        process.exitCode = 1;
-        console.error(error);
-    });
 }

--- a/test-other/integration_check_lib.mjs
+++ b/test-other/integration_check_lib.mjs
@@ -47,7 +47,7 @@ const testMetrics = [
 export async function main({ tagSuffix = '' } = {}) {
     if (tagSuffix) {
         for (const metric of testMetrics) {
-            metric.tags = metric.tags.map(tag => `${tag}${tagSuffix}`);
+            metric.tags = metric.tags.map(tag => `${tag}-${tagSuffix}`);
         }
     }
 


### PR DESCRIPTION
This package general works on Deno and Bun, but we’ve never formally said so. This adds integration tests for them and adds a note about it to the README.

(Inspired by my exploration of proxy support over in #132.)