### PR TITLE
GZIP reportet request bodies

### DIFF
--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -2,6 +2,7 @@
 const { fetch } = require('cross-fetch');
 const { AuthorizationError, DatadogMetricsError, HttpError } = require('./errors');
 const { logDebug, logDeprecation } = require('./logging');
+const {gzip} = require("pako");
 
 const RETRYABLE_ERROR_CODES = new Set([
     'ECONNREFUSED',
@@ -274,9 +275,10 @@ class DatadogReporter {
             method: 'POST',
             headers: {
                 'DD-API-KEY': datadogApiKeys.get(this),
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'Content-Encoding': 'gzip'
             },
-            body: JSON.stringify(options.body)
+            body: gzip(JSON.stringify(options.body))
         };
         return await this.httpApi.send(url, fetchOptions);
     }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   },
   "dependencies": {
     "cross-fetch": "^4.0.0",
-    "debug": "^4.1.0"
+    "debug": "^4.1.0",
+    "pako": "^2.1.0"
   },
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
GZIps the body of the requests to Datadog to prevent `PayloadTooLargeError: request entity too large` errors.