### PR TITLE
fix var name for backoff retry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ For changes to this repo, follow the [local development](#local-development) ste
     git checkout -b name-of-your-branch
     ```
 
-6. Make your changes to teh relevant files.
+6. Make your changes to the relevant files.
 
 7. Run tests and other checks before committing!
 

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ TBD
 
 **Bug Fixes:**
 
-TBD
+* Fixed issue where the `retryBackoff` option was not correctly applied in v0.13.0-pre.1. (Thanks to @jjedd97 in #155.)
 
 **Maintenance:**
 

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -175,7 +175,7 @@ class DatadogReporter {
         /** @private @type {HttpApi} */
         this.httpApi = new HttpApi({
             maxRetries: options.retries >= 0 ? options.retries : 2,
-            retryBackoff: options.retryBackoff >= 0 ? options.retryBackoff : 1
+            backoffBase: options.retryBackoff >= 0 ? options.retryBackoff : 1
         });
 
         /** @private @type {string} */

--- a/test/reporters_tests.js
+++ b/test/reporters_tests.js
@@ -23,6 +23,11 @@ describe('NullReporter', function() {
 });
 
 describe('DatadogReporter', function() {
+    const RETRY_BACKOFF_SECONDS = 0.01;
+    const RETRY_BACKOFF_MS = RETRY_BACKOFF_SECONDS * 1000;
+    // Timers can fire slightly early due to scheduler jitter, so allow a tiny buffer.
+    const MIN_RETRY_DELAY_MS = RETRY_BACKOFF_MS - 2;
+
     let originalEnv = Object.entries(process.env)
         .filter(([key, _]) => !/^(DD|DATADOG)_/.test(key));
 
@@ -71,7 +76,7 @@ describe('DatadogReporter', function() {
         beforeEach(() => {
             reporter = new DatadogReporter({
                 apiKey: 'abc',
-                retryBackoff: 0.01
+                retryBackoff: RETRY_BACKOFF_SECONDS
             });
         });
 
@@ -102,6 +107,29 @@ describe('DatadogReporter', function() {
                 .reply(202, { errors: [] });
 
             await reporter.report([mockMetric]).should.be.fulfilled;
+        });
+
+        it('should use configured retryBackoff for retries', async function () {
+            const callTimes = [];
+
+            nock('https://api.datadoghq.com')
+                .post('/api/v1/series')
+                .times(1)
+                .reply(() => {
+                    callTimes.push(Date.now());
+                    return [500, { errors: ['Unknown!'] }];
+                })
+                .post('/api/v1/series')
+                .times(1)
+                .reply(() => {
+                    callTimes.push(Date.now());
+                    return [202, { errors: [] }];
+                });
+
+            await reporter.report([mockMetric]).should.be.fulfilled;
+
+            const timeDelta = callTimes[1] - callTimes[0];
+            timeDelta.should.be.at.least(MIN_RETRY_DELAY_MS);
         });
 
         it('should respect the `Retry-After` header', async function () {

--- a/test/reporters_tests.js
+++ b/test/reporters_tests.js
@@ -24,9 +24,6 @@ describe('NullReporter', function() {
 
 describe('DatadogReporter', function() {
     const RETRY_BACKOFF_SECONDS = 0.01;
-    const RETRY_BACKOFF_MS = RETRY_BACKOFF_SECONDS * 1000;
-    // Timers can fire slightly early due to scheduler jitter, so allow a tiny buffer.
-    const MIN_RETRY_DELAY_MS = RETRY_BACKOFF_MS - 2;
 
     let originalEnv = Object.entries(process.env)
         .filter(([key, _]) => !/^(DD|DATADOG)_/.test(key));
@@ -110,7 +107,17 @@ describe('DatadogReporter', function() {
         });
 
         it('should use configured retryBackoff for retries', async function () {
+            const retryBackoffSeconds = 0.1;
+            const retryBackoffMs = retryBackoffSeconds * 1000;
+            // Timers can fire slightly early due to scheduler jitter.
+            const minRetryDelayMs = retryBackoffMs - 5;
+            // Event-loop contention (especially in CI) can delay retry scheduling.
+            const maxRetryDelayMs = retryBackoffMs + 30;
             const callTimes = [];
+            const retryBackoffReporter = new DatadogReporter({
+                apiKey: 'abc',
+                retryBackoff: retryBackoffSeconds
+            });
 
             nock('https://api.datadoghq.com')
                 .post('/api/v1/series')
@@ -126,10 +133,10 @@ describe('DatadogReporter', function() {
                     return [202, { errors: [] }];
                 });
 
-            await reporter.report([mockMetric]).should.be.fulfilled;
+            await retryBackoffReporter.report([mockMetric]).should.be.fulfilled;
 
             const timeDelta = callTimes[1] - callTimes[0];
-            timeDelta.should.be.at.least(MIN_RETRY_DELAY_MS);
+            timeDelta.should.be.within(minRetryDelayMs, maxRetryDelayMs);
         });
 
         it('should respect the `Retry-After` header', async function () {

--- a/test/reporters_tests.js
+++ b/test/reporters_tests.js
@@ -23,8 +23,6 @@ describe('NullReporter', function() {
 });
 
 describe('DatadogReporter', function() {
-    const RETRY_BACKOFF_SECONDS = 0.01;
-
     let originalEnv = Object.entries(process.env)
         .filter(([key, _]) => !/^(DD|DATADOG)_/.test(key));
 
@@ -73,7 +71,8 @@ describe('DatadogReporter', function() {
         beforeEach(() => {
             reporter = new DatadogReporter({
                 apiKey: 'abc',
-                retryBackoff: RETRY_BACKOFF_SECONDS
+                // Use an extremely short delay to keep tests quick.
+                retryBackoff: 0.01,
             });
         });
 
@@ -107,8 +106,8 @@ describe('DatadogReporter', function() {
         });
 
         it('should use configured retryBackoff for retries', async function () {
-            const retryBackoffSeconds = 0.1;
-            const retryBackoffMs = retryBackoffSeconds * 1000;
+            const retryBackoff = 0.1;
+            const retryBackoffMs = retryBackoff * 1000;
             // Timers can fire slightly early due to scheduler jitter.
             const minRetryDelayMs = retryBackoffMs - 5;
             // Event-loop contention (especially in CI) can delay retry scheduling.
@@ -116,7 +115,7 @@ describe('DatadogReporter', function() {
             const callTimes = [];
             const retryBackoffReporter = new DatadogReporter({
                 apiKey: 'abc',
-                retryBackoff: retryBackoffSeconds
+                retryBackoff
             });
 
             nock('https://api.datadoghq.com')


### PR DESCRIPTION
Fix to address mismatch in variables names for reporters.js backoff value 

Problem:
- If a message fails to send, the timer for HttpApi gets set to NaN

Original error:


`
(node:1) TimeoutNaNWarning: NaN is not a number.

Timeout duration was set to 1.

    at new Timeout (node:internal/timers:199:17)

    at setTimeout (node:timers:117:19)

    at /server/node_modules/datadog-metrics/lib/reporters.js:15:30

    at new Promise (<anonymous>)

    at sleep (/server/node_modules/datadog-metrics/lib/reporters.js:15:11)

    at HttpApi.send (/server/node_modules/datadog-metrics/lib/reporters.js:56:23)

    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)

    at async DatadogReporter.sendHttp (/server/node_modules/datadog-metrics/lib/reporters.js:281:16)

    at async Promise.all (index 0)

    at async DatadogReporter.report (/server/node_modules/datadog-metrics/lib/reporters.js:225:13)
    `